### PR TITLE
Trail Defense: Tower-Defense-Spiel + Ordnerstruktur pro Spiel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ UniTracks.Maui.Views      → Pages, Tabs, Controls (XAML), Custom Controls mit 
 UniTracks.Maui.Services   → Plattform-Services (GPS-Listener, Dispatcher)
 UniTracks.ViewModels      → ViewModels ([ObservableProperty], [RelayCommand])
 UniTracks.Services        → App-Logik (Tracking, Data-Services, Gamification, Game-Services)
-UniTracks.Games           → Spiele-Logik, dependency-frei (CityBuilder-Engine, Coin-Wirtschaft, Spiele-Katalog)
+UniTracks.Games           → Spiele-Logik, dependency-frei; ein Ordner pro Spiel (CityBuilder/, TowerDefense/),
+                            geteilter Code in Shared/ (Coin-Wirtschaft), Spiele-Katalog in Catalog/
 UniTracks.Data            → Persistenz: Entity Framework Core (SQLite) + LiteDB
 UniTracks.Models          → Domänen-Modelle (Trip, Location, User, Weather)
 UniTracks.Core            → Basis-Abstraktionen

--- a/UniTracks.Data/Migrations/20260905135105_TowerDefense.Designer.cs
+++ b/UniTracks.Data/Migrations/20260905135105_TowerDefense.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UniTracks.Data.SQLite;
 
@@ -10,14 +11,11 @@ using UniTracks.Data.SQLite;
 namespace UniTracks.Data.Migrations;
 
 [DbContext(typeof(SqliteDBContext))]
-partial class SqliteDBContextModelSnapshot : ModelSnapshot
+[Migration("20260905135105_TowerDefense")]
+partial class _20260905135105_TowerDefense
 {
-    // If you encounter a merge conflict in the line below, it means you need to
-    // discard one of the migration branches and recreate its migrations on top of
-    // the other branch. See https://aka.ms/efcore-docs-migrations-conflicts for more info.
-    public override string LastMigrationId => "20260905135105_TowerDefense";
-
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder.HasAnnotation("ProductVersion", "11.0.0-preview.7.26381.103");

--- a/UniTracks.Data/Migrations/20260905135105_TowerDefense.cs
+++ b/UniTracks.Data/Migrations/20260905135105_TowerDefense.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UniTracks.Data.Migrations;
+
+/// <inheritdoc />
+public partial class _20260905135105_TowerDefense : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "DefenseRecords",
+            columns: table => new
+            {
+                ID = table.Column<Guid>(type: "TEXT", nullable: false),
+                BestWave = table.Column<int>(type: "INTEGER", nullable: false),
+                BestScore = table.Column<int>(type: "INTEGER", nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_DefenseRecords", x => x.ID);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "TowerUnlocks",
+            columns: table => new
+            {
+                ID = table.Column<Guid>(type: "TEXT", nullable: false),
+                TowerId = table.Column<string>(type: "TEXT", nullable: false),
+                PurchasedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_TowerUnlocks", x => x.ID);
+            });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "DefenseRecords");
+
+        migrationBuilder.DropTable(
+            name: "TowerUnlocks");
+    }
+}

--- a/UniTracks.Data/SQLite/SqliteDBContext.cs
+++ b/UniTracks.Data/SQLite/SqliteDBContext.cs
@@ -3,7 +3,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.TowerDefense.Persistence;
 using UniTracks.Models.Constants;
 using UniTracks.Models.Environment;
 using UniTracks.Models.Health;
@@ -25,6 +26,8 @@ public class SqliteDBContext : DbContext
     public DbSet<User> Users { get; set; }
     public DbSet<PlacedBuilding> PlacedBuildings { get; set; }
     public DbSet<CityExpansion> CityExpansions { get; set; }
+    public DbSet<TowerUnlock> TowerUnlocks { get; set; }
+    public DbSet<DefenseRecord> DefenseRecords { get; set; }
 
     public DbContext Context => this;
     public string DatabasePath { get; }

--- a/UniTracks.Games/Catalog/GameCatalog.cs
+++ b/UniTracks.Games/Catalog/GameCatalog.cs
@@ -22,9 +22,9 @@ public static class GameCatalog
         {
             Id = "tower-defense",
             Title = "Trail Defense",
-            Description = "Verteidige deinen Trail gegen fiese Mücken. Bald verfügbar!",
+            Description = "Verteidige deinen Trail gegen fiese Mücken.",
             Icon = "🗼",
-            IsAvailable = false,
+            Route = "TowerDefensePage",
         },
     };
 

--- a/UniTracks.Games/CityBuilder/CityEngine.cs
+++ b/UniTracks.Games/CityBuilder/CityEngine.cs
@@ -1,5 +1,6 @@
-using UniTracks.Games.Economy;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.Shared.Economy;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Persistence;
 
 namespace UniTracks.Games.CityBuilder;
 

--- a/UniTracks.Games/CityBuilder/Persistence/CityExpansion.cs
+++ b/UniTracks.Games/CityBuilder/Persistence/CityExpansion.cs
@@ -1,4 +1,4 @@
-namespace UniTracks.Games.Persistence;
+namespace UniTracks.Games.CityBuilder.Persistence;
 
 /// <summary>
 /// A purchased city-grid expansion. Persisted via the provider-agnostic repository

--- a/UniTracks.Games/CityBuilder/Persistence/ICityStore.cs
+++ b/UniTracks.Games/CityBuilder/Persistence/ICityStore.cs
@@ -1,4 +1,4 @@
-namespace UniTracks.Games.Persistence;
+namespace UniTracks.Games.CityBuilder.Persistence;
 
 /// <summary>
 /// Persistence port for the city builder. Implemented in UniTracks.Services on top of

--- a/UniTracks.Games/CityBuilder/Persistence/PlacedBuilding.cs
+++ b/UniTracks.Games/CityBuilder/Persistence/PlacedBuilding.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace UniTracks.Games.Persistence;
+namespace UniTracks.Games.CityBuilder.Persistence;
 
 /// <summary>
 /// A building placed on the city map. This is the only persisted game state —

--- a/UniTracks.Games/Shared/Economy/CoinEconomy.cs
+++ b/UniTracks.Games/Shared/Economy/CoinEconomy.cs
@@ -1,6 +1,6 @@
-using UniTracks.Games.Persistence;
+using UniTracks.Games.Shared.Persistence;
 
-namespace UniTracks.Games.Economy;
+namespace UniTracks.Games.Shared.Economy;
 
 /// <summary>
 /// Coin economy rules. Coins are earned through real activity (trips, achievements)

--- a/UniTracks.Games/Shared/Economy/TripTypeFactors.cs
+++ b/UniTracks.Games/Shared/Economy/TripTypeFactors.cs
@@ -1,4 +1,4 @@
-namespace UniTracks.Games.Economy;
+namespace UniTracks.Games.Shared.Economy;
 
 /// <summary>
 /// Per-trip-type distance factors for the coin economy. A road cyclist covers the same

--- a/UniTracks.Games/Shared/Persistence/IActivityStatsSource.cs
+++ b/UniTracks.Games/Shared/Persistence/IActivityStatsSource.cs
@@ -1,4 +1,4 @@
-namespace UniTracks.Games.Persistence;
+namespace UniTracks.Games.Shared.Persistence;
 
 /// <summary>Aggregated activity numbers feeding the coin economy.</summary>
 public record ActivityStats

--- a/UniTracks.Games/Shared/Persistence/TripActivity.cs
+++ b/UniTracks.Games/Shared/Persistence/TripActivity.cs
@@ -1,4 +1,4 @@
-namespace UniTracks.Games.Persistence;
+namespace UniTracks.Games.Shared.Persistence;
 
 /// <summary>One recorded trip's contribution to the coin economy.</summary>
 public record TripActivity

--- a/UniTracks.Games/TowerDefense/ActiveEnemy.cs
+++ b/UniTracks.Games/TowerDefense/ActiveEnemy.cs
@@ -1,0 +1,21 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>An enemy currently on the trail, positioned by its travelled distance.</summary>
+public class ActiveEnemy
+{
+    /// <summary>Runtime identity — projectiles track their target by this id.</summary>
+    public int Id { get; init; }
+
+    public EnemyDefinition Definition { get; init; } = new();
+
+    /// <summary>Wave-scaled hit points this enemy spawned with (for health-bar rendering).</summary>
+    public int MaxHp { get; init; }
+
+    public int Hp { get; set; }
+
+    /// <summary>Distance travelled along the path in tile units (see <see cref="DefensePath"/>).</summary>
+    public double Distance { get; set; }
+
+    /// <summary>Current position on the grid, derived from <see cref="Distance"/>.</summary>
+    public (double X, double Y) Position => DefensePath.PositionAt(Distance);
+}

--- a/UniTracks.Games/TowerDefense/ActiveProjectile.cs
+++ b/UniTracks.Games/TowerDefense/ActiveProjectile.cs
@@ -1,0 +1,20 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>A projectile in flight, homing in on its target enemy.</summary>
+public class ActiveProjectile
+{
+    public double X { get; set; }
+
+    public double Y { get; set; }
+
+    /// <summary>Runtime id of the targeted <see cref="ActiveEnemy"/>.</summary>
+    public int TargetEnemyId { get; init; }
+
+    /// <summary>Travel speed in tiles per second (copied from the firing tower).</summary>
+    public double Speed { get; init; }
+
+    public int Damage { get; init; }
+
+    /// <summary>Render color (hex), copied from the firing tower.</summary>
+    public string ColorHex { get; init; } = "#FFFFFF";
+}

--- a/UniTracks.Games/TowerDefense/DefenseEngine.cs
+++ b/UniTracks.Games/TowerDefense/DefenseEngine.cs
@@ -42,7 +42,7 @@ public static class DefenseEngine
             return DefenseResult.Fail(DefenseError.UnknownTower);
         }
 
-        if (!state.UnlockedTowerIds.Contains(towerId))
+        if (!tower.IsFree && !state.UnlockedTowerIds.Contains(towerId))
         {
             return DefenseResult.Fail(DefenseError.TowerLocked);
         }

--- a/UniTracks.Games/TowerDefense/DefenseEngine.cs
+++ b/UniTracks.Games/TowerDefense/DefenseEngine.cs
@@ -1,0 +1,279 @@
+using UniTracks.Games.TowerDefense.Persistence;
+
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// Pure game logic for the trail defense game. No MAUI, SkiaSharp or EF dependencies —
+/// creates runs, validates placement/sell attempts and advances the simulation via
+/// <see cref="Tick"/>. Only unlocked towers and the best result are persisted;
+/// the run itself is pure runtime state.
+/// </summary>
+public static class DefenseEngine
+{
+    /// <summary>Energy every run starts with, so the first towers are placeable right away.</summary>
+    public const int StartingEnergy = 100;
+
+    public const int StartingLives = 20;
+
+    /// <summary>Fraction of the energy cost refunded when selling a tower.</summary>
+    public const double SellRefundFraction = 0.5;
+
+    /// <summary>Distance in tile units below which a projectile counts as a hit.</summary>
+    private const double HitRadius = 0.25;
+
+    /// <summary>Starts a fresh run for a player with the given permanently unlocked towers.</summary>
+    public static DefenseState NewRun(IEnumerable<string> unlockedTowerIds) => new()
+    {
+        UnlockedTowerIds = unlockedTowerIds.ToList(),
+        Energy = StartingEnergy,
+        Lives = StartingLives,
+    };
+
+    /// <summary>Coins permanently invested in tower unlocks (feeds the shared coin balance).</summary>
+    public static int ComputeUnlockSpent(IEnumerable<TowerUnlock> unlocks) =>
+        unlocks.Sum(u => TowerCatalog.Find(u.TowerId)?.UnlockCost ?? 0);
+
+    /// <summary>Validates a tower placement. Does not mutate anything.</summary>
+    public static DefenseResult ValidatePlacement(DefenseState state, string towerId, int x, int y)
+    {
+        var tower = TowerCatalog.Find(towerId);
+        if (tower is null)
+        {
+            return DefenseResult.Fail(DefenseError.UnknownTower);
+        }
+
+        if (!state.UnlockedTowerIds.Contains(towerId))
+        {
+            return DefenseResult.Fail(DefenseError.TowerLocked);
+        }
+
+        if (x < 0 || x >= DefensePath.GridWidth || y < 0 || y >= DefensePath.GridHeight)
+        {
+            return DefenseResult.Fail(DefenseError.OutOfBounds);
+        }
+
+        if (DefensePath.IsPath(x, y))
+        {
+            return DefenseResult.Fail(DefenseError.NotBuildable);
+        }
+
+        if (state.TowerAt(x, y) is not null)
+        {
+            return DefenseResult.Fail(DefenseError.TileOccupied);
+        }
+
+        if (state.Energy < tower.EnergyCost)
+        {
+            return DefenseResult.Fail(DefenseError.NotEnoughEnergy);
+        }
+
+        return DefenseResult.Ok(-tower.EnergyCost);
+    }
+
+    /// <summary>Validates and places a tower, spending energy on success.</summary>
+    public static DefenseResult PlaceTower(DefenseState state, string towerId, int x, int y)
+    {
+        var validation = ValidatePlacement(state, towerId, x, y);
+        if (!validation.Success)
+        {
+            return validation;
+        }
+
+        state.Towers.Add(new PlacedTower { X = x, Y = y, TowerId = towerId });
+        state.Energy += validation.EnergyDelta;
+        return validation;
+    }
+
+    /// <summary>Validates and sells a tower, refunding half of its energy cost.</summary>
+    public static DefenseResult SellTower(DefenseState state, int x, int y)
+    {
+        var tower = state.TowerAt(x, y);
+        if (tower is null)
+        {
+            return DefenseResult.Fail(DefenseError.TileEmpty);
+        }
+
+        int refund = (int)Math.Floor((TowerCatalog.Find(tower.TowerId)?.EnergyCost ?? 0) * SellRefundFraction);
+        state.Towers.Remove(tower);
+        state.Energy += refund;
+        return DefenseResult.Ok(refund);
+    }
+
+    /// <summary>Queues the next wave and switches the run into <see cref="DefensePhase.WaveRunning"/>.</summary>
+    public static DefenseResult StartWave(DefenseState state)
+    {
+        if (state.Phase == DefensePhase.WaveRunning)
+        {
+            return DefenseResult.Fail(DefenseError.WaveRunning);
+        }
+
+        foreach (var enemy in WaveCatalog.For(state.NextWave))
+        {
+            state.PendingSpawns.Enqueue(enemy);
+        }
+
+        state.SpawnCooldownMs = 0;
+        state.Phase = DefensePhase.WaveRunning;
+        return DefenseResult.Ok(0);
+    }
+
+    /// <summary>
+    /// Advances the simulation by <paramref name="deltaMs"/>: spawning, enemy movement,
+    /// tower fire, projectile hits, kills, leaks and wave/run transitions.
+    /// </summary>
+    public static void Tick(DefenseState state, double deltaMs)
+    {
+        if (state.Phase != DefensePhase.WaveRunning)
+        {
+            return;
+        }
+
+        double deltaSeconds = deltaMs / 1000.0;
+
+        SpawnEnemies(state, deltaMs);
+        MoveEnemies(state, deltaSeconds);
+        FireTowers(state, deltaMs);
+        MoveProjectiles(state, deltaSeconds);
+
+        if (state.Lives <= 0)
+        {
+            state.Lives = 0;
+            state.Phase = DefensePhase.Lost;
+            state.Enemies.Clear();
+            state.Projectiles.Clear();
+            state.PendingSpawns.Clear();
+            return;
+        }
+
+        if (state.PendingSpawns.Count == 0 && state.Enemies.Count == 0)
+        {
+            state.Energy += WaveCatalog.ClearBonus(state.NextWave);
+            state.NextWave++;
+            state.Phase = DefensePhase.Building;
+        }
+    }
+
+    private static void SpawnEnemies(DefenseState state, double deltaMs)
+    {
+        state.SpawnCooldownMs -= deltaMs;
+        double hpMultiplier = WaveCatalog.HpMultiplier(state.NextWave);
+
+        while (state.PendingSpawns.Count > 0 && state.SpawnCooldownMs <= 0)
+        {
+            var definition = state.PendingSpawns.Dequeue();
+            int maxHp = (int)Math.Ceiling(definition.BaseHp * hpMultiplier);
+            state.Enemies.Add(new ActiveEnemy
+            {
+                Id = state.NextEnemyId++,
+                Definition = definition,
+                MaxHp = maxHp,
+                Hp = maxHp,
+                Distance = 0,
+            });
+
+            state.SpawnCooldownMs += WaveCatalog.SpawnIntervalMs;
+        }
+    }
+
+    private static void MoveEnemies(DefenseState state, double deltaSeconds)
+    {
+        for (int i = state.Enemies.Count - 1; i >= 0; i--)
+        {
+            var enemy = state.Enemies[i];
+            enemy.Distance += enemy.Definition.SpeedTilesPerSecond * deltaSeconds;
+            if (enemy.Distance >= DefensePath.TotalLength)
+            {
+                state.Lives -= enemy.Definition.LeakDamage;
+                state.Enemies.RemoveAt(i);
+                state.Projectiles.RemoveAll(p => p.TargetEnemyId == enemy.Id);
+            }
+        }
+    }
+
+    private static void FireTowers(DefenseState state, double deltaMs)
+    {
+        foreach (var tower in state.Towers)
+        {
+            tower.CooldownRemainingMs -= deltaMs;
+            if (tower.CooldownRemainingMs > 0)
+            {
+                continue;
+            }
+
+            var definition = TowerCatalog.Find(tower.TowerId);
+            if (definition is null)
+            {
+                continue;
+            }
+
+            // Target the enemy furthest along the trail within range.
+            var target = state.Enemies
+                .Where(e => DistanceTo(tower, e) <= definition.RangeTiles)
+                .OrderByDescending(e => e.Distance)
+                .FirstOrDefault();
+            if (target is null)
+            {
+                tower.CooldownRemainingMs = 0;
+                continue;
+            }
+
+            state.Projectiles.Add(new ActiveProjectile
+            {
+                X = tower.X + 0.5,
+                Y = tower.Y + 0.5,
+                TargetEnemyId = target.Id,
+                Speed = definition.ProjectileSpeed,
+                Damage = definition.Damage,
+                ColorHex = definition.ColorHex,
+            });
+
+            tower.CooldownRemainingMs = definition.FireIntervalMs;
+        }
+    }
+
+    private static void MoveProjectiles(DefenseState state, double deltaSeconds)
+    {
+        for (int i = state.Projectiles.Count - 1; i >= 0; i--)
+        {
+            var projectile = state.Projectiles[i];
+            var target = state.Enemies.FirstOrDefault(e => e.Id == projectile.TargetEnemyId);
+            if (target is null)
+            {
+                state.Projectiles.RemoveAt(i);
+                continue;
+            }
+
+            var (tx, ty) = target.Position;
+            double dx = tx - projectile.X;
+            double dy = ty - projectile.Y;
+            double distance = Math.Sqrt(dx * dx + dy * dy);
+            double step = projectile.Speed * deltaSeconds;
+
+            if (distance <= Math.Max(step, HitRadius))
+            {
+                target.Hp -= projectile.Damage;
+                state.Projectiles.RemoveAt(i);
+                if (target.Hp <= 0)
+                {
+                    state.Energy += target.Definition.EnergyReward;
+                    state.Score += target.Definition.ScoreReward;
+                    state.Enemies.Remove(target);
+                    state.Projectiles.RemoveAll(p => p.TargetEnemyId == target.Id);
+                }
+            }
+            else
+            {
+                projectile.X += dx / distance * step;
+                projectile.Y += dy / distance * step;
+            }
+        }
+    }
+
+    private static double DistanceTo(PlacedTower tower, ActiveEnemy enemy)
+    {
+        var (ex, ey) = enemy.Position;
+        double dx = ex - (tower.X + 0.5);
+        double dy = ey - (tower.Y + 0.5);
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}

--- a/UniTracks.Games/TowerDefense/DefensePath.cs
+++ b/UniTracks.Games/TowerDefense/DefensePath.cs
@@ -1,0 +1,83 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// The fixed trail the enemies march along. The path is defined by waypoints on a
+/// top-down grid; positions are expressed in tile units with tile centers at (x+0.5, y+0.5).
+/// Pure geometry — computing a position from a travelled distance never allocates.
+/// </summary>
+public static class DefensePath
+{
+    public const int GridWidth = 9;
+
+    public const int GridHeight = 15;
+
+    /// <summary>Waypoints in tile coordinates. The trail enters above the grid and leaves below it.</summary>
+    private static readonly (double X, double Y)[] Waypoints =
+    {
+        (2.5, -0.5),
+        (2.5, 4.5),
+        (6.5, 4.5),
+        (6.5, 8.5),
+        (2.5, 8.5),
+        (2.5, 12.5),
+        (6.5, 12.5),
+        (6.5, 15.5),
+    };
+
+    private static readonly double[] SegmentLengths = ComputeSegmentLengths();
+
+    /// <summary>Total path length in tile units. Enemies leak when their distance exceeds this.</summary>
+    public static double TotalLength { get; } = SegmentLengths.Sum();
+
+    /// <summary>Resolves a travelled distance to a position on the path (clamped at both ends).</summary>
+    public static (double X, double Y) PositionAt(double distance)
+    {
+        double remaining = Math.Clamp(distance, 0, TotalLength);
+        for (int i = 0; i < SegmentLengths.Length; i++)
+        {
+            if (remaining <= SegmentLengths[i])
+            {
+                double t = SegmentLengths[i] <= 0 ? 0 : remaining / SegmentLengths[i];
+                return (
+                    Waypoints[i].X + (Waypoints[i + 1].X - Waypoints[i].X) * t,
+                    Waypoints[i].Y + (Waypoints[i + 1].Y - Waypoints[i].Y) * t);
+            }
+
+            remaining -= SegmentLengths[i];
+        }
+
+        return Waypoints[^1];
+    }
+
+    /// <summary>True when the tile belongs to the trail (and therefore cannot be built on).</summary>
+    public static bool IsPath(int x, int y)
+    {
+        for (int i = 0; i < Waypoints.Length - 1; i++)
+        {
+            var (x1, y1) = Waypoints[i];
+            var (x2, y2) = Waypoints[i + 1];
+            int minX = (int)Math.Floor(Math.Min(x1, x2));
+            int maxX = (int)Math.Floor(Math.Max(x1, x2));
+            int minY = (int)Math.Floor(Math.Min(y1, y2));
+            int maxY = (int)Math.Floor(Math.Max(y1, y2));
+            if (x >= minX && x <= maxX && y >= minY && y <= maxY)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static double[] ComputeSegmentLengths()
+    {
+        var lengths = new double[Waypoints.Length - 1];
+        for (int i = 0; i < lengths.Length; i++)
+        {
+            lengths[i] = Math.Abs(Waypoints[i + 1].X - Waypoints[i].X)
+                       + Math.Abs(Waypoints[i + 1].Y - Waypoints[i].Y);
+        }
+
+        return lengths;
+    }
+}

--- a/UniTracks.Games/TowerDefense/DefensePhase.cs
+++ b/UniTracks.Games/TowerDefense/DefensePhase.cs
@@ -1,0 +1,14 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Lifecycle phase of a defense run.</summary>
+public enum DefensePhase
+{
+    /// <summary>Between waves — towers can be placed and the next wave can be started.</summary>
+    Building,
+
+    /// <summary>A wave is marching down the trail.</summary>
+    WaveRunning,
+
+    /// <summary>All lives lost — the run is over and the score can be saved.</summary>
+    Lost,
+}

--- a/UniTracks.Games/TowerDefense/DefenseProfile.cs
+++ b/UniTracks.Games/TowerDefense/DefenseProfile.cs
@@ -1,0 +1,19 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// Snapshot of the player's persistent trail-defense progress: spendable coin balance,
+/// unlocked towers and the best result so far. Loaded by the service layer whenever
+/// the game screen is shown or a purchase changes the balance.
+/// </summary>
+public record DefenseProfile
+{
+    /// <summary>Spendable coins (earned from activity minus all game spending).</summary>
+    public int Coins { get; init; }
+
+    public IReadOnlyList<string> UnlockedTowerIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>Highest wave ever fully cleared (0 = no finished run yet).</summary>
+    public int BestWave { get; init; }
+
+    public int BestScore { get; init; }
+}

--- a/UniTracks.Games/TowerDefense/DefenseResult.cs
+++ b/UniTracks.Games/TowerDefense/DefenseResult.cs
@@ -1,0 +1,51 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Validation errors for in-run actions, mapped to user-facing messages.</summary>
+public enum DefenseError
+{
+    UnknownTower,
+    TowerLocked,
+    OutOfBounds,
+    NotBuildable,
+    TileOccupied,
+    NotEnoughEnergy,
+    TileEmpty,
+    WaveRunning,
+}
+
+/// <summary>
+/// Outcome of a validated in-run action (placement, sell). Mirrors the city builder's
+/// <c>PlaceResult</c> pattern: nothing is mutated on failure.
+/// </summary>
+public record DefenseResult
+{
+    private DefenseResult(DefenseError? error, int energyDelta)
+    {
+        Error = error;
+        EnergyDelta = energyDelta;
+    }
+
+    public bool Success => Error is null;
+
+    public DefenseError? Error { get; }
+
+    /// <summary>Energy gained (sell refund) or spent (placement) by the action.</summary>
+    public int EnergyDelta { get; }
+
+    public string ErrorMessage => Error switch
+    {
+        DefenseError.UnknownTower => "Unbekannter Turm.",
+        DefenseError.TowerLocked => "Dieser Turm ist noch nicht freigeschaltet.",
+        DefenseError.OutOfBounds => "Außerhalb des Spielfelds.",
+        DefenseError.NotBuildable => "Auf dem Trail kann nicht gebaut werden.",
+        DefenseError.TileOccupied => "Dieses Feld ist bereits belegt.",
+        DefenseError.NotEnoughEnergy => "Nicht genug Energie — besiege erst ein paar Mücken!",
+        DefenseError.TileEmpty => "Hier steht kein Turm.",
+        DefenseError.WaveRunning => "Warte, bis die Welle vorbei ist.",
+        _ => string.Empty,
+    };
+
+    public static DefenseResult Ok(int energyDelta) => new(null, energyDelta);
+
+    public static DefenseResult Fail(DefenseError error) => new(error, 0);
+}

--- a/UniTracks.Games/TowerDefense/DefenseState.cs
+++ b/UniTracks.Games/TowerDefense/DefenseState.cs
@@ -1,0 +1,51 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// Mutable runtime state of one defense run. Created via <see cref="DefenseEngine.NewRun"/>
+/// and advanced exclusively through <see cref="DefenseEngine.Tick"/> — never persisted;
+/// only tower unlocks and the best result survive a run.
+/// </summary>
+public class DefenseState
+{
+    public List<PlacedTower> Towers { get; } = new();
+
+    public List<ActiveEnemy> Enemies { get; } = new();
+
+    public List<ActiveProjectile> Projectiles { get; } = new();
+
+    /// <summary>Tower ids the player has permanently unlocked (drives placement validation).</summary>
+    public IReadOnlyList<string> UnlockedTowerIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>In-run placement currency, earned by killing enemies and clearing waves.</summary>
+    public int Energy { get; set; }
+
+    public int Lives { get; set; }
+
+    public int Score { get; set; }
+
+    /// <summary>Number of the wave that will start next (1-based).</summary>
+    public int NextWave { get; set; } = 1;
+
+    public DefensePhase Phase { get; set; } = DefensePhase.Building;
+
+    /// <summary>Enemies of the running wave that still need to spawn.</summary>
+    public Queue<EnemyDefinition> PendingSpawns { get; } = new();
+
+    /// <summary>Milliseconds until the next pending enemy spawns.</summary>
+    public double SpawnCooldownMs { get; set; }
+
+    /// <summary>Number of the last wave that was fully cleared (0 = none yet).</summary>
+    public int ClearedWave => Phase == DefensePhase.Building ? NextWave - 1 : NextWave;
+
+    /// <summary>Monotonic runtime id source for spawned enemies (projectile targeting).</summary>
+    public int NextEnemyId { get; set; } = 1;
+
+    public PlacedTower? TowerAt(int x, int y) => Towers.FirstOrDefault(t => t.X == x && t.Y == y);
+
+    /// <summary>True when the tile is inside the grid, off the trail and not occupied.</summary>
+    public bool IsBuildable(int x, int y) =>
+        x >= 0 && x < DefensePath.GridWidth
+        && y >= 0 && y < DefensePath.GridHeight
+        && !DefensePath.IsPath(x, y)
+        && TowerAt(x, y) is null;
+}

--- a/UniTracks.Games/TowerDefense/DefenseTile.cs
+++ b/UniTracks.Games/TowerDefense/DefenseTile.cs
@@ -1,0 +1,4 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>A grid tile tapped on the defense map — command parameter for tile interactions.</summary>
+public record DefenseTile(int X, int Y);

--- a/UniTracks.Games/TowerDefense/EnemyCatalog.cs
+++ b/UniTracks.Games/TowerDefense/EnemyCatalog.cs
@@ -1,0 +1,15 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Static catalog of all enemy types for the trail defense game.</summary>
+public static class EnemyCatalog
+{
+    public static IReadOnlyList<EnemyDefinition> Enemies { get; } = new List<EnemyDefinition>
+    {
+        new() { Id = "mosquito", Name = "Mücke", Icon = "🦟", BaseHp = 10, SpeedTilesPerSecond = 1.2, EnergyReward = 5, ScoreReward = 10 },
+        new() { Id = "gnat", Name = "Schnake", Icon = "🪰", BaseHp = 30, SpeedTilesPerSecond = 0.85, EnergyReward = 8, ScoreReward = 20 },
+        new() { Id = "wasp", Name = "Wespe", Icon = "🐝", BaseHp = 55, SpeedTilesPerSecond = 1.6, EnergyReward = 12, ScoreReward = 40 },
+        new() { Id = "hornet", Name = "Hornisse", Icon = "🪲", BaseHp = 220, SpeedTilesPerSecond = 0.65, EnergyReward = 35, ScoreReward = 120, LeakDamage = 3 },
+    };
+
+    public static EnemyDefinition? Find(string id) => Enemies.FirstOrDefault(e => e.Id == id);
+}

--- a/UniTracks.Games/TowerDefense/EnemyDefinition.cs
+++ b/UniTracks.Games/TowerDefense/EnemyDefinition.cs
@@ -1,0 +1,26 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Static definition of an enemy type marching down the trail.</summary>
+public record EnemyDefinition
+{
+    public string Id { get; init; } = string.Empty;
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Icon { get; init; } = "🦟";
+
+    /// <summary>Base hit points (scaled up per wave by <see cref="WaveCatalog"/>).</summary>
+    public int BaseHp { get; init; }
+
+    /// <summary>Movement speed in tiles per second.</summary>
+    public double SpeedTilesPerSecond { get; init; }
+
+    /// <summary>Energy awarded for a kill (the in-run placement currency).</summary>
+    public int EnergyReward { get; init; }
+
+    /// <summary>Score points awarded for a kill (feeds the highscore).</summary>
+    public int ScoreReward { get; init; }
+
+    /// <summary>Lives lost when this enemy reaches the end of the trail.</summary>
+    public int LeakDamage { get; init; } = 1;
+}

--- a/UniTracks.Games/TowerDefense/Persistence/DefenseRecord.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/DefenseRecord.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UniTracks.Games.TowerDefense.Persistence;
+
+/// <summary>
+/// The player's best trail-defense result (single row). Updated whenever a finished
+/// run beats the stored wave or score.
+/// </summary>
+public record DefenseRecord
+{
+    [Key]
+    public Guid ID { get; init; }
+
+    /// <summary>Highest wave number that was fully cleared.</summary>
+    public int BestWave { get; set; }
+
+    public int BestScore { get; set; }
+
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/UniTracks.Games/TowerDefense/Persistence/ITowerDefenseStore.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/ITowerDefenseStore.cs
@@ -1,0 +1,16 @@
+namespace UniTracks.Games.TowerDefense.Persistence;
+
+/// <summary>
+/// Persistence port for the trail defense game. Implemented in UniTracks.Services on
+/// top of the provider-agnostic <c>IRepository</c> (EF Core + SQLite, LiteDB on iOS).
+/// </summary>
+public interface ITowerDefenseStore
+{
+    Task<IReadOnlyList<TowerUnlock>> LoadUnlocksAsync();
+
+    Task SaveUnlockAsync(TowerUnlock unlock);
+
+    Task<DefenseRecord?> LoadRecordAsync();
+
+    Task SaveRecordAsync(DefenseRecord record);
+}

--- a/UniTracks.Games/TowerDefense/Persistence/TowerUnlock.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/TowerUnlock.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UniTracks.Games.TowerDefense.Persistence;
+
+/// <summary>
+/// A permanently unlocked tower type, purchased with coins. Coin balance is always
+/// computed (earned from activity minus all spending), so unlocks are the only
+/// persisted tower state. Works on EF Core (SQLite) as well as LiteDB on iOS.
+/// </summary>
+public record TowerUnlock
+{
+    [Key]
+    public Guid ID { get; init; }
+
+    /// <summary>References <c>TowerDefinition.Id</c> from the static catalog.</summary>
+    public string TowerId { get; init; } = string.Empty;
+
+    public DateTimeOffset PurchasedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/UniTracks.Games/TowerDefense/PlacedTower.cs
+++ b/UniTracks.Games/TowerDefense/PlacedTower.cs
@@ -1,0 +1,15 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>A tower placed on the grid during a run, with its remaining fire cooldown.</summary>
+public class PlacedTower
+{
+    public int X { get; init; }
+
+    public int Y { get; init; }
+
+    /// <summary>References <see cref="TowerDefinition.Id"/> from the static catalog.</summary>
+    public string TowerId { get; init; } = string.Empty;
+
+    /// <summary>Milliseconds until the tower can fire again.</summary>
+    public double CooldownRemainingMs { get; set; }
+}

--- a/UniTracks.Games/TowerDefense/TowerCatalog.cs
+++ b/UniTracks.Games/TowerDefense/TowerCatalog.cs
@@ -1,0 +1,16 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Static shop catalog of all unlockable towers for the trail defense game.</summary>
+public static class TowerCatalog
+{
+    public static IReadOnlyList<TowerDefinition> Towers { get; } = new List<TowerDefinition>
+    {
+        new() { Id = "spray", Name = "Mückenspray", Description = "Schnelle Sprühstöße auf kurze Distanz.", Icon = "🧴", UnlockCost = 0, EnergyCost = 25, RangeTiles = 2.0, Damage = 4, FireIntervalMs = 550, ColorHex = "#4FC3F7" },
+        new() { Id = "candle", Name = "Duftkerze", Description = "Räuchert gleichmäßig alles in der Nähe aus.", Icon = "🕯️", UnlockCost = 100, EnergyCost = 45, RangeTiles = 2.5, Damage = 8, FireIntervalMs = 900, ColorHex = "#FFB74D" },
+        new() { Id = "zapper", Name = "Elektro-Falle", Description = "Langsam, aber vernichtend.", Icon = "⚡", UnlockCost = 250, EnergyCost = 80, RangeTiles = 2.0, Damage = 22, FireIntervalMs = 1600, ColorHex = "#FFF176" },
+        new() { Id = "frog", Name = "Frosch", Description = "Schnappt weit entfernte Mücken aus der Luft.", Icon = "🐸", UnlockCost = 400, EnergyCost = 120, RangeTiles = 3.5, Damage = 14, FireIntervalMs = 1100, ColorHex = "#81C784" },
+        new() { Id = "gecko", Name = "Gecko", Description = "Der Endgegner für jeden Mückenschwarm.", Icon = "🦎", UnlockCost = 700, EnergyCost = 200, RangeTiles = 3.0, Damage = 38, FireIntervalMs = 1500, ColorHex = "#BA68C8" },
+    };
+
+    public static TowerDefinition? Find(string id) => Towers.FirstOrDefault(t => t.Id == id);
+}

--- a/UniTracks.Games/TowerDefense/TowerDefinition.cs
+++ b/UniTracks.Games/TowerDefense/TowerDefinition.cs
@@ -1,0 +1,37 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// Static definition of a tower type. Towers are unlocked permanently with coins
+/// (financed by real activity) and placed during a run with energy earned from kills.
+/// </summary>
+public record TowerDefinition
+{
+    public string Id { get; init; } = string.Empty;
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Description { get; init; } = string.Empty;
+
+    public string Icon { get; init; } = "🗼";
+
+    /// <summary>One-time coin price to unlock the tower permanently (0 = starter tower).</summary>
+    public int UnlockCost { get; init; }
+
+    /// <summary>Energy price to place the tower during a run.</summary>
+    public int EnergyCost { get; init; }
+
+    /// <summary>Attack range in tile units (center to center).</summary>
+    public double RangeTiles { get; init; }
+
+    /// <summary>Damage dealt per projectile hit.</summary>
+    public int Damage { get; init; }
+
+    /// <summary>Milliseconds between two shots.</summary>
+    public int FireIntervalMs { get; init; }
+
+    /// <summary>Projectile travel speed in tiles per second.</summary>
+    public double ProjectileSpeed { get; init; } = 6;
+
+    /// <summary>Render color (hex) used for the tower base and its projectiles.</summary>
+    public string ColorHex { get; init; } = "#8BC34A";
+}

--- a/UniTracks.Games/TowerDefense/TowerDefinition.cs
+++ b/UniTracks.Games/TowerDefense/TowerDefinition.cs
@@ -34,4 +34,7 @@ public record TowerDefinition
 
     /// <summary>Render color (hex) used for the tower base and its projectiles.</summary>
     public string ColorHex { get; init; } = "#8BC34A";
+
+    /// <summary>Starter towers need no coin unlock and are always placeable.</summary>
+    public bool IsFree => UnlockCost == 0;
 }

--- a/UniTracks.Games/TowerDefense/UnlockResult.cs
+++ b/UniTracks.Games/TowerDefense/UnlockResult.cs
@@ -1,0 +1,19 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>Outcome of a permanent tower unlock purchase.</summary>
+public record UnlockResult
+{
+    private UnlockResult(string? errorMessage)
+    {
+        ErrorMessage = errorMessage ?? string.Empty;
+    }
+
+    public bool Success => ErrorMessage.Length == 0;
+
+    /// <summary>User-facing failure reason ("" on success).</summary>
+    public string ErrorMessage { get; }
+
+    public static UnlockResult Ok() => new((string?)null);
+
+    public static UnlockResult Fail(string message) => new(message);
+}

--- a/UniTracks.Games/TowerDefense/WaveCatalog.cs
+++ b/UniTracks.Games/TowerDefense/WaveCatalog.cs
@@ -1,0 +1,52 @@
+namespace UniTracks.Games.TowerDefense;
+
+/// <summary>
+/// Procedural wave composition. Waves scale endlessly: later waves add tougher enemy
+/// types and multiply hit points, every fifth wave sends a hornet as boss.
+/// </summary>
+public static class WaveCatalog
+{
+    /// <summary>Milliseconds between two enemy spawns within a wave.</summary>
+    public const int SpawnIntervalMs = 800;
+
+    /// <summary>Hit-point multiplier per wave (wave 1 = 100 %, growing by 15 % each wave).</summary>
+    public static double HpMultiplier(int wave) => 1 + 0.15 * (wave - 1);
+
+    /// <summary>Energy bonus awarded when a wave is fully cleared.</summary>
+    public static int ClearBonus(int wave) => 20 + 5 * wave;
+
+    /// <summary>
+    /// The enemy types spawning in the given wave, in spawn order. Waves stay endless —
+    /// composition and hit points simply keep scaling.
+    /// </summary>
+    public static IReadOnlyList<EnemyDefinition> For(int wave)
+    {
+        var enemies = new List<EnemyDefinition>();
+
+        int mosquitoes = 4 + wave;
+        int gnats = wave >= 3 ? (wave - 1) : 0;
+        int wasps = wave >= 5 ? (wave - 3) : 0;
+
+        for (int i = 0; i < mosquitoes; i++)
+        {
+            enemies.Add(EnemyCatalog.Find("mosquito")!);
+        }
+
+        for (int i = 0; i < gnats; i++)
+        {
+            enemies.Add(EnemyCatalog.Find("gnat")!);
+        }
+
+        for (int i = 0; i < wasps; i++)
+        {
+            enemies.Add(EnemyCatalog.Find("wasp")!);
+        }
+
+        if (wave % 5 == 0)
+        {
+            enemies.Add(EnemyCatalog.Find("hornet")!);
+        }
+
+        return enemies;
+    }
+}

--- a/UniTracks.Maui.Views/Controls/Game/DefenseMapView.cs
+++ b/UniTracks.Maui.Views/Controls/Game/DefenseMapView.cs
@@ -1,0 +1,323 @@
+using System.Diagnostics;
+using System.Windows.Input;
+using SkiaSharp;
+using SkiaSharp.Views.Maui;
+using SkiaSharp.Views.Maui.Controls;
+using UniTracks.Games.TowerDefense;
+
+namespace UniTracks.Maui.Views.Controls.Game;
+
+/// <summary>
+/// SkiaSharp-rendered top-down map for the trail defense game. Draws the trail,
+/// placed towers with range preview, marching enemies with health bars and homing
+/// projectiles. Drives the simulation by executing <see cref="TickCommand"/> from a
+/// ~30 fps timer and forwards tile taps via <see cref="TileTappedCommand"/>.
+/// </summary>
+public class DefenseMapView : SKCanvasView
+{
+    private static readonly SKColor GrassA = new(46, 71, 52);
+    private static readonly SKColor GrassB = new(41, 64, 47);
+    private static readonly SKColor PathColor = new(112, 89, 64);
+    private static readonly SKColor PathEdge = new(91, 71, 50);
+
+    private readonly Stopwatch tickWatch = new();
+    private readonly IDispatcherTimer gameTimer;
+
+    /// <summary>Tile tapped most recently — anchors the ghost preview of the selected tower.</summary>
+    private (int X, int Y)? lastTappedTile;
+
+    public DefenseMapView()
+    {
+        EnableTouchEvents = true;
+        Touch += OnTouch;
+
+        gameTimer = Dispatcher.CreateTimer();
+        gameTimer.Interval = TimeSpan.FromMilliseconds(33);
+        gameTimer.Tick += OnGameTick;
+        gameTimer.Start();
+        tickWatch.Start();
+    }
+
+    public static readonly BindableProperty StateProperty = BindableProperty.Create(
+        nameof(State), typeof(DefenseState), typeof(DefenseMapView),
+        propertyChanged: static (b, _, _) => ((DefenseMapView)b).InvalidateSurface());
+
+    public DefenseState? State
+    {
+        get => (DefenseState?)GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    public static readonly BindableProperty GhostTowerProperty = BindableProperty.Create(
+        nameof(GhostTower), typeof(TowerDefinition), typeof(DefenseMapView),
+        propertyChanged: static (b, _, _) => ((DefenseMapView)b).InvalidateSurface());
+
+    /// <summary>Tower selected in the shop — shown as ghost preview with range circle.</summary>
+    public TowerDefinition? GhostTower
+    {
+        get => (TowerDefinition?)GetValue(GhostTowerProperty);
+        set => SetValue(GhostTowerProperty, value);
+    }
+
+    public static readonly BindableProperty TileTappedCommandProperty = BindableProperty.Create(
+        nameof(TileTappedCommand), typeof(ICommand), typeof(DefenseMapView));
+
+    public ICommand? TileTappedCommand
+    {
+        get => (ICommand?)GetValue(TileTappedCommandProperty);
+        set => SetValue(TileTappedCommandProperty, value);
+    }
+
+    public static readonly BindableProperty TickCommandProperty = BindableProperty.Create(
+        nameof(TickCommand), typeof(ICommand), typeof(DefenseMapView));
+
+    /// <summary>Executed every frame with the elapsed milliseconds — advances the simulation.</summary>
+    public ICommand? TickCommand
+    {
+        get => (ICommand?)GetValue(TickCommandProperty);
+        set => SetValue(TickCommandProperty, value);
+    }
+
+    // Physical pixel size of the canvas, captured during paint — the single source of
+    // truth for hit-testing so taps and rendering always agree (no Density math).
+    private float canvasWidth;
+    private float canvasHeight;
+
+    private float TileSize => Math.Min(canvasWidth / DefensePath.GridWidth, canvasHeight / DefensePath.GridHeight);
+
+    private float OriginX => (canvasWidth - TileSize * DefensePath.GridWidth) / 2f;
+
+    private float OriginY => (canvasHeight - TileSize * DefensePath.GridHeight) / 2f;
+
+    private void OnGameTick(object? sender, EventArgs e)
+    {
+        int elapsedMs = (int)Math.Min(tickWatch.ElapsedMilliseconds, 100);
+        tickWatch.Restart();
+
+        if (State is not null && TickCommand?.CanExecute(elapsedMs) == true)
+        {
+            TickCommand.Execute(elapsedMs);
+        }
+
+        InvalidateSurface();
+    }
+
+    private void OnTouch(object? sender, SKTouchEventArgs e)
+    {
+        if (e.ActionType != SKTouchAction.Pressed || TileTappedCommand is null)
+        {
+            return;
+        }
+
+        int x = (int)Math.Floor((e.Location.X - OriginX) / TileSize);
+        int y = (int)Math.Floor((e.Location.Y - OriginY) / TileSize);
+        if (x < 0 || x >= DefensePath.GridWidth || y < 0 || y >= DefensePath.GridHeight)
+        {
+            return;
+        }
+
+        lastTappedTile = (x, y);
+        var tile = new DefenseTile(x, y);
+        if (TileTappedCommand.CanExecute(tile))
+        {
+            TileTappedCommand.Execute(tile);
+        }
+
+        InvalidateSurface();
+        e.Handled = true;
+    }
+
+    protected override void OnPaintSurface(SKPaintSurfaceEventArgs e)
+    {
+        var canvas = e.Surface.Canvas;
+        canvasWidth = e.Info.Width;
+        canvasHeight = e.Info.Height;
+        canvas.Clear(new SKColor(24, 31, 27));
+
+        if (State is null)
+        {
+            return;
+        }
+
+        DrawTiles(canvas);
+        DrawGhost(canvas);
+        DrawTowers(canvas);
+        DrawEnemies(canvas);
+        DrawProjectiles(canvas);
+    }
+
+    private void DrawTiles(SKCanvas canvas)
+    {
+        using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        float ts = TileSize;
+
+        for (int y = 0; y < DefensePath.GridHeight; y++)
+        {
+            for (int x = 0; x < DefensePath.GridWidth; x++)
+            {
+                var rect = CellRect(x, y, inset: 0.5f);
+                paint.Color = (x + y) % 2 == 0 ? GrassA : GrassB;
+                canvas.DrawRect(rect, paint);
+
+                if (DefensePath.IsPath(x, y))
+                {
+                    paint.Color = PathColor;
+                    canvas.DrawRect(rect, paint);
+                }
+            }
+        }
+
+        // Trail entry and goal markers.
+        DrawEmoji(canvas, "🌲", 2, -1, ts * 0.8f);
+        DrawEmoji(canvas, "⛺", 6, DefensePath.GridHeight - 1, ts * 0.7f);
+    }
+
+    private void DrawGhost(SKCanvas canvas)
+    {
+        if (GhostTower is null || lastTappedTile is not { } tile || State is null || !State.IsBuildable(tile.X, tile.Y))
+        {
+            return;
+        }
+
+        float ts = TileSize;
+        float cx = OriginX + (tile.X + 0.5f) * ts;
+        float cy = OriginY + (tile.Y + 0.5f) * ts;
+
+        using var rangePaint = new SKPaint
+        {
+            Color = new SKColor(255, 255, 255, 28),
+            Style = SKPaintStyle.Fill,
+            IsAntialias = true,
+        };
+        canvas.DrawCircle(cx, cy, (float)GhostTower.RangeTiles * ts, rangePaint);
+
+        using var ghostPaint = new SKPaint
+        {
+            Color = SKColor.Parse(GhostTower.ColorHex).WithAlpha(140),
+            Style = SKPaintStyle.Fill,
+            IsAntialias = true,
+        };
+        canvas.DrawCircle(cx, cy, ts * 0.38f, ghostPaint);
+        DrawEmoji(canvas, GhostTower.Icon, tile.X, tile.Y, ts * 0.5f, alpha: 180);
+    }
+
+    private void DrawTowers(SKCanvas canvas)
+    {
+        if (State is null)
+        {
+            return;
+        }
+
+        float ts = TileSize;
+        foreach (var tower in State.Towers)
+        {
+            var definition = TowerCatalog.Find(tower.TowerId);
+            float cx = OriginX + (tower.X + 0.5f) * ts;
+            float cy = OriginY + (tower.Y + 0.5f) * ts;
+
+            using var basePaint = new SKPaint
+            {
+                Color = SKColor.Parse(definition?.ColorHex ?? "#8BC34A"),
+                Style = SKPaintStyle.Fill,
+                IsAntialias = true,
+            };
+            canvas.DrawCircle(cx, cy, ts * 0.38f, basePaint);
+
+            using var ringPaint = new SKPaint
+            {
+                Color = new SKColor(0, 0, 0, 90),
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = 2,
+                IsAntialias = true,
+            };
+            canvas.DrawCircle(cx, cy, ts * 0.38f, ringPaint);
+
+            DrawEmoji(canvas, definition?.Icon ?? "🗼", tower.X, tower.Y, ts * 0.5f);
+        }
+    }
+
+    private void DrawEnemies(SKCanvas canvas)
+    {
+        if (State is null)
+        {
+            return;
+        }
+
+        float ts = TileSize;
+        foreach (var enemy in State.Enemies)
+        {
+            var (ex, ey) = enemy.Position;
+            float px = OriginX + (float)ex * ts;
+            float py = OriginY + (float)ey * ts;
+
+            using var textPaint = new SKPaint
+            {
+                TextSize = ts * 0.55f,
+                TextAlign = SKTextAlign.Center,
+                IsAntialias = true,
+            };
+            canvas.DrawText(enemy.Definition.Icon, px, py + ts * 0.2f, textPaint);
+
+            // Health bar above the enemy (only when damaged).
+            if (enemy.Hp < enemy.MaxHp)
+            {
+                float barWidth = ts * 0.6f;
+                float barLeft = px - barWidth / 2f;
+                float barTop = py - ts * 0.42f;
+                using var backPaint = new SKPaint { Color = new SKColor(0, 0, 0, 120), Style = SKPaintStyle.Fill };
+                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth, barTop + ts * 0.08f), backPaint);
+
+                float fraction = Math.Max(0, (float)enemy.Hp / enemy.MaxHp);
+                using var hpPaint = new SKPaint { Color = new SKColor(77, 231, 144), Style = SKPaintStyle.Fill };
+                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth * fraction, barTop + ts * 0.08f), hpPaint);
+            }
+        }
+    }
+
+    private void DrawProjectiles(SKCanvas canvas)
+    {
+        if (State is null)
+        {
+            return;
+        }
+
+        float ts = TileSize;
+        foreach (var projectile in State.Projectiles)
+        {
+            using var paint = new SKPaint
+            {
+                Color = SKColor.Parse(projectile.ColorHex),
+                Style = SKPaintStyle.Fill,
+                IsAntialias = true,
+            };
+            canvas.DrawCircle(
+                OriginX + (float)projectile.X * ts,
+                OriginY + (float)projectile.Y * ts,
+                ts * 0.09f,
+                paint);
+        }
+    }
+
+    private SKRect CellRect(int x, int y, float inset)
+    {
+        float ts = TileSize;
+        return new SKRect(
+            OriginX + x * ts + inset,
+            OriginY + y * ts + inset,
+            OriginX + (x + 1) * ts - inset,
+            OriginY + (y + 1) * ts - inset);
+    }
+
+    private void DrawEmoji(SKCanvas canvas, string emoji, int tileX, int tileY, float size, byte alpha = 255)
+    {
+        float ts = TileSize;
+        using var paint = new SKPaint
+        {
+            TextSize = size,
+            TextAlign = SKTextAlign.Center,
+            IsAntialias = true,
+            Color = SKColors.White.WithAlpha(alpha),
+        };
+        canvas.DrawText(emoji, OriginX + (tileX + 0.5f) * ts, OriginY + (tileY + 0.72f) * ts, paint);
+    }
+}

--- a/UniTracks.Maui.Views/Controls/Game/DefenseMapView.cs
+++ b/UniTracks.Maui.Views/Controls/Game/DefenseMapView.cs
@@ -8,23 +8,45 @@ using UniTracks.Games.TowerDefense;
 namespace UniTracks.Maui.Views.Controls.Game;
 
 /// <summary>
-/// SkiaSharp-rendered top-down map for the trail defense game. Draws the trail,
-/// placed towers with range preview, marching enemies with health bars and homing
+/// SkiaSharp-rendered isometric map for the trail defense game, using the same
+/// projection as <see cref="CityMapView"/>: grass/dirt diamonds with 3D side faces,
+/// towers standing on their tiles, marching enemies with health bars and homing
 /// projectiles. Drives the simulation by executing <see cref="TickCommand"/> from a
-/// ~30 fps timer and forwards tile taps via <see cref="TileTappedCommand"/>.
+/// ~30 fps timer, forwards tile taps via <see cref="TileTappedCommand"/> and supports
+/// pan and pinch-zoom.
 /// </summary>
 public class DefenseMapView : SKCanvasView
 {
-    private static readonly SKColor GrassA = new(46, 71, 52);
-    private static readonly SKColor GrassB = new(41, 64, 47);
-    private static readonly SKColor PathColor = new(112, 89, 64);
-    private static readonly SKColor PathEdge = new(91, 71, 50);
+    /// <summary>Half the number of tiles along a diamond diagonal — sizes the iso layout.</summary>
+    private const double HalfSpan = (DefensePath.GridWidth + DefensePath.GridHeight) / 2.0;
+
+    private static readonly SKColor SkyTop = new(18, 26, 22);
+    private static readonly SKColor SkyBottom = new(30, 44, 35);
 
     private readonly Stopwatch tickWatch = new();
     private readonly IDispatcherTimer gameTimer;
 
+    private double panX;
+    private double panY;
+    private double zoom = 1;
+
+    private double panStartX;
+    private double panStartY;
+    private double touchStartX;
+    private double touchStartY;
+    private bool isPanning;
+    private bool isPinching;
+    private double pinchStartZoom = 1;
+    private float pinchStartDistance;
+    private readonly Dictionary<long, SKPoint> activeTouches = new();
+
     /// <summary>Tile tapped most recently — anchors the ghost preview of the selected tower.</summary>
-    private (int X, int Y)? lastTappedTile;
+    private (int X, int Y)? selectedTile;
+
+    // Physical pixel size of the canvas, captured during paint — the single source of
+    // truth for hit-testing so taps and rendering always agree (no Density math).
+    private float canvasWidth;
+    private float canvasHeight;
 
     public DefenseMapView()
     {
@@ -52,7 +74,7 @@ public class DefenseMapView : SKCanvasView
         nameof(GhostTower), typeof(TowerDefinition), typeof(DefenseMapView),
         propertyChanged: static (b, _, _) => ((DefenseMapView)b).InvalidateSurface());
 
-    /// <summary>Tower selected in the shop — shown as ghost preview with range circle.</summary>
+    /// <summary>Tower selected in the shop — shown as ghost preview with range indicator.</summary>
     public TowerDefinition? GhostTower
     {
         get => (TowerDefinition?)GetValue(GhostTowerProperty);
@@ -78,16 +100,24 @@ public class DefenseMapView : SKCanvasView
         set => SetValue(TickCommandProperty, value);
     }
 
-    // Physical pixel size of the canvas, captured during paint — the single source of
-    // truth for hit-testing so taps and rendering always agree (no Density math).
-    private float canvasWidth;
-    private float canvasHeight;
+    /// <summary>Isometric projection state for the current canvas size, pan and zoom.</summary>
+    private readonly record struct IsoLayout(double TileW, double TileH, double OriginX, double OriginY)
+    {
+        /// <summary>Maps a tile-space point (tile centers at x+0.5, y+0.5) to screen coordinates.</summary>
+        public double ScreenX(double x, double y) => OriginX + (x - y) * TileW / 2.0;
 
-    private float TileSize => Math.Min(canvasWidth / DefensePath.GridWidth, canvasHeight / DefensePath.GridHeight);
+        public double ScreenY(double x, double y) => OriginY + (x + y) * TileH / 2.0;
+    }
 
-    private float OriginX => (canvasWidth - TileSize * DefensePath.GridWidth) / 2f;
-
-    private float OriginY => (canvasHeight - TileSize * DefensePath.GridHeight) / 2f;
+    private IsoLayout CurrentLayout()
+    {
+        // Fit the full diamond width to the canvas; vertical space is centered.
+        double tileW = canvasWidth * 0.96 / HalfSpan * zoom;
+        double tileH = tileW / 2.0;
+        double originX = canvasWidth / 2.0 + panX;
+        double originY = (canvasHeight - HalfSpan * tileH) / 2.0 + panY;
+        return new IsoLayout(tileW, tileH, originX, originY);
+    }
 
     private void OnGameTick(object? sender, EventArgs e)
     {
@@ -104,27 +134,124 @@ public class DefenseMapView : SKCanvasView
 
     private void OnTouch(object? sender, SKTouchEventArgs e)
     {
-        if (e.ActionType != SKTouchAction.Pressed || TileTappedCommand is null)
+        switch (e.ActionType)
         {
+            case SKTouchAction.Pressed:
+                if (e.InContact)
+                {
+                    activeTouches[e.Id] = e.Location;
+
+                    if (activeTouches.Count == 2)
+                    {
+                        // Second finger down: switch to pinch mode.
+                        var points = activeTouches.Values.ToArray();
+                        pinchStartDistance = Distance(points[0], points[1]);
+                        pinchStartZoom = zoom;
+                        isPinching = true;
+                        isPanning = false;
+                        selectedTile = null;
+                    }
+                    else
+                    {
+                        touchStartX = e.Location.X;
+                        touchStartY = e.Location.Y;
+                        panStartX = panX;
+                        panStartY = panY;
+                        isPanning = false;
+                    }
+
+                    e.Handled = true;
+                }
+                break;
+
+            case SKTouchAction.Moved:
+                if (e.InContact && activeTouches.ContainsKey(e.Id))
+                {
+                    activeTouches[e.Id] = e.Location;
+
+                    if (isPinching && activeTouches.Count >= 2)
+                    {
+                        var points = activeTouches.Values.ToArray();
+                        float distance = Distance(points[0], points[1]);
+                        if (pinchStartDistance > 0)
+                        {
+                            zoom = Math.Clamp(pinchStartZoom * (distance / pinchStartDistance), 0.6, 2.2);
+                            InvalidateSurface();
+                        }
+                    }
+                    else if (!isPinching)
+                    {
+                        double dx = e.Location.X - touchStartX;
+                        double dy = e.Location.Y - touchStartY;
+                        if (isPanning || Math.Abs(dx) + Math.Abs(dy) > 12)
+                        {
+                            isPanning = true;
+                            panX = panStartX + dx;
+                            panY = panStartY + dy;
+                            selectedTile = null;
+                            InvalidateSurface();
+                        }
+                    }
+
+                    e.Handled = true;
+                }
+                break;
+
+            case SKTouchAction.WheelChanged:
+                zoom = Math.Clamp(zoom * (e.WheelDelta > 0 ? 1.1 : 0.9), 0.6, 2.2);
+                InvalidateSurface();
+                e.Handled = true;
+                break;
+
+            case SKTouchAction.Released:
+                activeTouches.Remove(e.Id);
+
+                if (isPinching)
+                {
+                    isPinching = activeTouches.Count >= 2;
+                }
+                else if (!isPanning && activeTouches.Count == 0)
+                {
+                    HandleTap(e.Location);
+                }
+
+                if (activeTouches.Count == 0)
+                {
+                    isPanning = false;
+                }
+
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void HandleTap(SKPoint point)
+    {
+        var layout = CurrentLayout();
+
+        // Inverse isometric transform: screen → tile coordinates.
+        double dx = point.X - layout.OriginX;
+        double dy = point.Y - layout.OriginY;
+        double fx = (dx / (layout.TileW / 2.0) + dy / (layout.TileH / 2.0)) / 2.0;
+        double fy = (dy / (layout.TileH / 2.0) - dx / (layout.TileW / 2.0)) / 2.0;
+        int tx = (int)Math.Floor(fx);
+        int ty = (int)Math.Floor(fy);
+
+        if (tx < 0 || ty < 0 || tx >= DefensePath.GridWidth || ty >= DefensePath.GridHeight)
+        {
+            selectedTile = null;
+            InvalidateSurface();
             return;
         }
 
-        int x = (int)Math.Floor((e.Location.X - OriginX) / TileSize);
-        int y = (int)Math.Floor((e.Location.Y - OriginY) / TileSize);
-        if (x < 0 || x >= DefensePath.GridWidth || y < 0 || y >= DefensePath.GridHeight)
-        {
-            return;
-        }
+        selectedTile = (tx, ty);
+        InvalidateSurface();
 
-        lastTappedTile = (x, y);
-        var tile = new DefenseTile(x, y);
-        if (TileTappedCommand.CanExecute(tile))
+        var tile = new DefenseTile(tx, ty);
+        if (TileTappedCommand?.CanExecute(tile) == true)
         {
             TileTappedCommand.Execute(tile);
         }
-
-        InvalidateSurface();
-        e.Handled = true;
     }
 
     protected override void OnPaintSurface(SKPaintSurfaceEventArgs e)
@@ -132,156 +259,236 @@ public class DefenseMapView : SKCanvasView
         var canvas = e.Surface.Canvas;
         canvasWidth = e.Info.Width;
         canvasHeight = e.Info.Height;
-        canvas.Clear(new SKColor(24, 31, 27));
+
+        DrawBackground(canvas);
 
         if (State is null)
         {
             return;
         }
 
-        DrawTiles(canvas);
-        DrawGhost(canvas);
-        DrawTowers(canvas);
-        DrawEnemies(canvas);
-        DrawProjectiles(canvas);
+        var layout = CurrentLayout();
+        DrawTiles(canvas, layout);
+        DrawGhost(canvas, layout);
+        DrawEnemies(canvas, layout);
+        DrawProjectiles(canvas, layout);
     }
 
-    private void DrawTiles(SKCanvas canvas)
+    private void DrawBackground(SKCanvas canvas)
     {
-        using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
-        float ts = TileSize;
+        using var paint = new SKPaint
+        {
+            Shader = SKShader.CreateLinearGradient(
+                new SKPoint(0, 0), new SKPoint(0, canvasHeight),
+                new[] { SkyTop, SkyBottom }, null, SKShaderTileMode.Clamp),
+        };
+        canvas.DrawRect(new SKRect(0, 0, canvasWidth, canvasHeight), paint);
+    }
 
+    private void DrawTiles(SKCanvas canvas, IsoLayout layout)
+    {
+        // Painter's algorithm: back row (y=0) first, so front tiles overlap correctly.
         for (int y = 0; y < DefensePath.GridHeight; y++)
         {
             for (int x = 0; x < DefensePath.GridWidth; x++)
             {
-                var rect = CellRect(x, y, inset: 0.5f);
-                paint.Color = (x + y) % 2 == 0 ? GrassA : GrassB;
-                canvas.DrawRect(rect, paint);
+                bool isGhostTarget = selectedTile == (x, y) && GhostTower is not null && (State?.IsBuildable(x, y) ?? false);
+                DrawTile(canvas, layout, x, y, isGhostTarget);
 
-                if (DefensePath.IsPath(x, y))
+                var tower = State?.TowerAt(x, y);
+                if (tower is not null)
                 {
-                    paint.Color = PathColor;
-                    canvas.DrawRect(rect, paint);
+                    DrawTower(canvas, layout, tower, alpha: 255);
                 }
             }
         }
 
-        // Trail entry and goal markers.
-        DrawEmoji(canvas, "🌲", 2, -1, ts * 0.8f);
-        DrawEmoji(canvas, "⛺", 6, DefensePath.GridHeight - 1, ts * 0.7f);
+        // Trail entry and goal markers just outside the grid.
+        DrawEmoji(canvas, "🌲", layout.ScreenX(2.5, -0.5), layout.ScreenY(2.5, -0.5), (float)(layout.TileW * 0.45));
+        DrawEmoji(canvas, "⛺", layout.ScreenX(6.5, 15.5), layout.ScreenY(6.5, 15.5), (float)(layout.TileW * 0.4));
     }
 
-    private void DrawGhost(SKCanvas canvas)
+    private void DrawTile(SKCanvas canvas, IsoLayout layout, int x, int y, bool isGhostTarget)
     {
-        if (GhostTower is null || lastTappedTile is not { } tile || State is null || !State.IsBuildable(tile.X, tile.Y))
+        // Deterministic per-tile grass variation.
+        int hash = (x * 31 + y * 17) % 5;
+        byte g = (byte)(84 + hash * 5);
+        var top = new SKColor(58, g, 64);
+        var side = new SKColor(42, 62, 47);
+
+        if (DefensePath.IsPath(x, y))
         {
-            return;
+            top = new SKColor(112, 89, 64);
+            side = new SKColor(91, 71, 50);
+        }
+        else if (isGhostTarget)
+        {
+            top = new SKColor(96, 150, 108);
+            side = new SKColor(72, 118, 84);
         }
 
-        float ts = TileSize;
-        float cx = OriginX + (tile.X + 0.5f) * ts;
-        float cy = OriginY + (tile.Y + 0.5f) * ts;
+        float cx = (float)layout.ScreenX(x + 0.5, y + 0.5);
+        float cy = (float)layout.ScreenY(x + 0.5, y + 0.5);
+        float hw = (float)(layout.TileW / 2.0);
+        float hh = (float)(layout.TileH / 2.0);
 
-        using var rangePaint = new SKPaint
+        // Side faces for a subtle 3D feel.
+        using (var sidePath = new SKPath())
         {
-            Color = new SKColor(255, 255, 255, 28),
-            Style = SKPaintStyle.Fill,
-            IsAntialias = true,
-        };
-        canvas.DrawCircle(cx, cy, (float)GhostTower.RangeTiles * ts, rangePaint);
-
-        using var ghostPaint = new SKPaint
-        {
-            Color = SKColor.Parse(GhostTower.ColorHex).WithAlpha(140),
-            Style = SKPaintStyle.Fill,
-            IsAntialias = true,
-        };
-        canvas.DrawCircle(cx, cy, ts * 0.38f, ghostPaint);
-        DrawEmoji(canvas, GhostTower.Icon, tile.X, tile.Y, ts * 0.5f, alpha: 180);
-    }
-
-    private void DrawTowers(SKCanvas canvas)
-    {
-        if (State is null)
-        {
-            return;
+            sidePath.MoveTo(cx - hw, cy);
+            sidePath.LineTo(cx, cy + hh);
+            sidePath.LineTo(cx + hw, cy);
+            sidePath.LineTo(cx + hw, cy + hh * 0.25f);
+            sidePath.LineTo(cx, cy + hh * 1.25f);
+            sidePath.LineTo(cx - hw, cy + hh * 0.25f);
+            sidePath.Close();
+            using var sidePaint = new SKPaint { Color = side, Style = SKPaintStyle.Fill, IsAntialias = true };
+            canvas.DrawPath(sidePath, sidePaint);
         }
 
-        float ts = TileSize;
-        foreach (var tower in State.Towers)
+        using var topPath = new SKPath();
+        topPath.MoveTo(cx, cy - hh);
+        topPath.LineTo(cx + hw, cy);
+        topPath.LineTo(cx, cy + hh);
+        topPath.LineTo(cx - hw, cy);
+        topPath.Close();
+        using var topPaint = new SKPaint { Color = top, Style = SKPaintStyle.Fill, IsAntialias = true };
+        canvas.DrawPath(topPath, topPaint);
+
+        if (isGhostTarget)
         {
-            var definition = TowerCatalog.Find(tower.TowerId);
-            float cx = OriginX + (tower.X + 0.5f) * ts;
-            float cy = OriginY + (tower.Y + 0.5f) * ts;
-
-            using var basePaint = new SKPaint
+            using var stroke = new SKPaint
             {
-                Color = SKColor.Parse(definition?.ColorHex ?? "#8BC34A"),
-                Style = SKPaintStyle.Fill,
-                IsAntialias = true,
-            };
-            canvas.DrawCircle(cx, cy, ts * 0.38f, basePaint);
-
-            using var ringPaint = new SKPaint
-            {
-                Color = new SKColor(0, 0, 0, 90),
+                Color = new SKColor(77, 231, 144),
                 Style = SKPaintStyle.Stroke,
-                StrokeWidth = 2,
+                StrokeWidth = 3,
                 IsAntialias = true,
             };
-            canvas.DrawCircle(cx, cy, ts * 0.38f, ringPaint);
-
-            DrawEmoji(canvas, definition?.Icon ?? "🗼", tower.X, tower.Y, ts * 0.5f);
+            canvas.DrawPath(topPath, stroke);
         }
     }
 
-    private void DrawEnemies(SKCanvas canvas)
+    private void DrawGhost(SKCanvas canvas, IsoLayout layout)
+    {
+        if (GhostTower is null || selectedTile is not { } tile || State is null || !State.IsBuildable(tile.X, tile.Y))
+        {
+            return;
+        }
+
+        double cx = layout.ScreenX(tile.X + 0.5, tile.Y + 0.5);
+        double cy = layout.ScreenY(tile.X + 0.5, tile.Y + 0.5);
+
+        // Range circle in tile space, sampled and projected (becomes an ellipse on screen).
+        using var rangePath = new SKPath();
+        const int segments = 28;
+        for (int i = 0; i <= segments; i++)
+        {
+            double angle = i * 2.0 * Math.PI / segments;
+            double px = tile.X + 0.5 + Math.Cos(angle) * GhostTower.RangeTiles;
+            double py = tile.Y + 0.5 + Math.Sin(angle) * GhostTower.RangeTiles;
+            float sx = (float)layout.ScreenX(px, py);
+            float sy = (float)layout.ScreenY(px, py);
+            if (i == 0)
+            {
+                rangePath.MoveTo(sx, sy);
+            }
+            else
+            {
+                rangePath.LineTo(sx, sy);
+            }
+        }
+
+        rangePath.Close();
+        using var rangePaint = new SKPaint { Color = new SKColor(255, 255, 255, 24), Style = SKPaintStyle.Fill, IsAntialias = true };
+        canvas.DrawPath(rangePath, rangePaint);
+        using var rangeStroke = new SKPaint { Color = new SKColor(255, 255, 255, 70), Style = SKPaintStyle.Stroke, StrokeWidth = 2, IsAntialias = true };
+        canvas.DrawPath(rangePath, rangeStroke);
+
+        DrawTowerBase(canvas, (float)cx, (float)cy, layout, GhostTower, alpha: 140);
+        DrawEmoji(canvas, GhostTower.Icon, cx, cy - layout.TileH * 0.55, (float)(layout.TileW * 0.34), alpha: 180);
+    }
+
+    private void DrawTower(SKCanvas canvas, IsoLayout layout, PlacedTower tower, byte alpha)
+    {
+        var definition = TowerCatalog.Find(tower.TowerId);
+        float cx = (float)layout.ScreenX(tower.X + 0.5, tower.Y + 0.5);
+        float cy = (float)layout.ScreenY(tower.X + 0.5, tower.Y + 0.5);
+
+        DrawTowerBase(canvas, cx, cy, layout, definition, alpha);
+        DrawEmoji(canvas, definition?.Icon ?? "🗼", cx, cy - layout.TileH * 0.55, (float)(layout.TileW * 0.34), alpha);
+    }
+
+    private void DrawTowerBase(SKCanvas canvas, float cx, float cy, IsoLayout layout, TowerDefinition? definition, byte alpha)
+    {
+        float rx = (float)(layout.TileW * 0.17);
+        float ry = (float)(layout.TileH * 0.3);
+
+        using var shadowPaint = new SKPaint { Color = new SKColor(0, 0, 0, 60), Style = SKPaintStyle.Fill, IsAntialias = true };
+        canvas.DrawOval(cx, cy + ry * 0.3f, rx * 1.15f, ry * 1.15f, shadowPaint);
+
+        using var basePaint = new SKPaint
+        {
+            Color = SKColor.Parse(definition?.ColorHex ?? "#8BC34A").WithAlpha(alpha),
+            Style = SKPaintStyle.Fill,
+            IsAntialias = true,
+        };
+        canvas.DrawOval(cx, cy, rx, ry, basePaint);
+
+        using var ringPaint = new SKPaint
+        {
+            Color = new SKColor(0, 0, 0, 90),
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 2,
+            IsAntialias = true,
+        };
+        canvas.DrawOval(cx, cy, rx, ry, ringPaint);
+    }
+
+    private void DrawEnemies(SKCanvas canvas, IsoLayout layout)
     {
         if (State is null)
         {
             return;
         }
 
-        float ts = TileSize;
-        foreach (var enemy in State.Enemies)
+        // Painter's algorithm: sort back-to-front by iso depth so figures overlap correctly.
+        foreach (var enemy in State.Enemies.OrderBy(e => e.Position.X + e.Position.Y))
         {
             var (ex, ey) = enemy.Position;
-            float px = OriginX + (float)ex * ts;
-            float py = OriginY + (float)ey * ts;
+            float px = (float)layout.ScreenX(ex, ey);
+            float py = (float)layout.ScreenY(ex, ey);
+            float size = (float)(layout.TileW * 0.3);
 
-            using var textPaint = new SKPaint
-            {
-                TextSize = ts * 0.55f,
-                TextAlign = SKTextAlign.Center,
-                IsAntialias = true,
-            };
-            canvas.DrawText(enemy.Definition.Icon, px, py + ts * 0.2f, textPaint);
+            using var shadowPaint = new SKPaint { Color = new SKColor(0, 0, 0, 60), Style = SKPaintStyle.Fill, IsAntialias = true };
+            canvas.DrawOval(px, py + (float)(layout.TileH * 0.15), size * 0.4f, size * 0.14f, shadowPaint);
+
+            DrawEmoji(canvas, enemy.Definition.Icon, px, py - layout.TileH * 0.35, size);
 
             // Health bar above the enemy (only when damaged).
             if (enemy.Hp < enemy.MaxHp)
             {
-                float barWidth = ts * 0.6f;
+                float barWidth = (float)(layout.TileW * 0.28);
+                float barHeight = Math.Max(3, (float)(layout.TileH * 0.1));
                 float barLeft = px - barWidth / 2f;
-                float barTop = py - ts * 0.42f;
-                using var backPaint = new SKPaint { Color = new SKColor(0, 0, 0, 120), Style = SKPaintStyle.Fill };
-                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth, barTop + ts * 0.08f), backPaint);
+                float barTop = py - (float)(layout.TileH * 0.35) - size * 0.75f;
+
+                using var backPaint = new SKPaint { Color = new SKColor(0, 0, 0, 120), Style = SKPaintStyle.Fill, IsAntialias = true };
+                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth, barTop + barHeight), backPaint);
 
                 float fraction = Math.Max(0, (float)enemy.Hp / enemy.MaxHp);
-                using var hpPaint = new SKPaint { Color = new SKColor(77, 231, 144), Style = SKPaintStyle.Fill };
-                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth * fraction, barTop + ts * 0.08f), hpPaint);
+                using var hpPaint = new SKPaint { Color = new SKColor(77, 231, 144), Style = SKPaintStyle.Fill, IsAntialias = true };
+                canvas.DrawRect(new SKRect(barLeft, barTop, barLeft + barWidth * fraction, barTop + barHeight), hpPaint);
             }
         }
     }
 
-    private void DrawProjectiles(SKCanvas canvas)
+    private void DrawProjectiles(SKCanvas canvas, IsoLayout layout)
     {
         if (State is null)
         {
             return;
         }
 
-        float ts = TileSize;
         foreach (var projectile in State.Projectiles)
         {
             using var paint = new SKPaint
@@ -291,26 +498,15 @@ public class DefenseMapView : SKCanvasView
                 IsAntialias = true,
             };
             canvas.DrawCircle(
-                OriginX + (float)projectile.X * ts,
-                OriginY + (float)projectile.Y * ts,
-                ts * 0.09f,
+                (float)layout.ScreenX(projectile.X, projectile.Y),
+                (float)(layout.ScreenY(projectile.X, projectile.Y) - layout.TileH * 0.3),
+                (float)(layout.TileW * 0.045),
                 paint);
         }
     }
 
-    private SKRect CellRect(int x, int y, float inset)
+    private static void DrawEmoji(SKCanvas canvas, string emoji, double centerX, double centerY, float size, byte alpha = 255)
     {
-        float ts = TileSize;
-        return new SKRect(
-            OriginX + x * ts + inset,
-            OriginY + y * ts + inset,
-            OriginX + (x + 1) * ts - inset,
-            OriginY + (y + 1) * ts - inset);
-    }
-
-    private void DrawEmoji(SKCanvas canvas, string emoji, int tileX, int tileY, float size, byte alpha = 255)
-    {
-        float ts = TileSize;
         using var paint = new SKPaint
         {
             TextSize = size,
@@ -318,6 +514,9 @@ public class DefenseMapView : SKCanvasView
             IsAntialias = true,
             Color = SKColors.White.WithAlpha(alpha),
         };
-        canvas.DrawText(emoji, OriginX + (tileX + 0.5f) * ts, OriginY + (tileY + 0.72f) * ts, paint);
+        canvas.DrawText(emoji, (float)centerX, (float)centerY + size * 0.35f, paint);
     }
+
+    private static float Distance(SKPoint a, SKPoint b) =>
+        (float)Math.Sqrt(Math.Pow(a.X - b.X, 2) + Math.Pow(a.Y - b.Y, 2));
 }

--- a/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml
+++ b/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="UniTracks.Maui.Views.Pages.TowerDefensePage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:gameControls="clr-namespace:UniTracks.Maui.Views.Controls.Game"
+    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:viewModels="clr-namespace:UniTracks.ViewModels.Pages;assembly=UniTracks.ViewModels"
+    Title="Trail Defense"
+    x:DataType="viewModels:TowerDefensePageViewModel">
+
+    <Grid RowDefinitions="Auto,*,Auto">
+
+        <!-- Top bar: coins + energy + lives + wave + sell toggle -->
+        <Grid Grid.Row="0" Padding="12,10" ColumnDefinitions="Auto,Auto,Auto,*,Auto" ColumnSpacing="8">
+            <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                <HorizontalStackLayout Spacing="6">
+                    <Label FontSize="16" Text="🪙" VerticalOptions="Center" />
+                    <Label Style="{StaticResource TitleLabel}" Text="{Binding Profile.Coins, StringFormat='{0:N0}'}" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+            <Border Grid.Column="1" Padding="12,8" Style="{StaticResource CardBorder}">
+                <HorizontalStackLayout Spacing="6">
+                    <Label FontSize="16" Text="⚡" VerticalOptions="Center" />
+                    <Label Style="{StaticResource TitleLabel}" Text="{Binding EnergyLabel}" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+            <Border Grid.Column="2" Padding="12,8" Style="{StaticResource CardBorder}">
+                <HorizontalStackLayout Spacing="6">
+                    <Label FontSize="16" Text="❤️" VerticalOptions="Center" />
+                    <Label Style="{StaticResource TitleLabel}" Text="{Binding LivesLabel}" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+            <Border Grid.Column="3" Padding="12,8" Style="{StaticResource CardBorder}">
+                <VerticalStackLayout Spacing="0">
+                    <Label Style="{StaticResource TitleLabel}" Text="{Binding WaveLabel}" />
+                    <Label FontSize="10" Style="{StaticResource SubtitleLabel}" Text="{Binding BestLabel}" />
+                </VerticalStackLayout>
+            </Border>
+            <Border Grid.Column="4" Padding="12,8" Style="{StaticResource CardBorder}">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ToggleSellModeCommand}" />
+                </Border.GestureRecognizers>
+                <Label FontSize="18" Text="💥" VerticalOptions="Center" HorizontalOptions="Center" />
+                <Border.Triggers>
+                    <DataTrigger Binding="{Binding IsSellMode}" TargetType="Border" Value="True">
+                        <Setter Property="BackgroundColor" Value="{StaticResource AccentSoft}" />
+                        <Setter Property="Stroke" Value="{StaticResource Accent}" />
+                    </DataTrigger>
+                </Border.Triggers>
+            </Border>
+        </Grid>
+
+        <!-- Defense map with game-over overlay -->
+        <Grid Grid.Row="1">
+            <gameControls:DefenseMapView
+                GhostTower="{Binding SelectedTower}"
+                State="{Binding State}"
+                TickCommand="{Binding TickCommand}"
+                TileTappedCommand="{Binding TileTappedCommand}" />
+
+            <Border
+                BackgroundColor="#CC121A14"
+                IsVisible="{Binding IsLost}"
+                Padding="28"
+                Stroke="{StaticResource Accent}"
+                StrokeThickness="2"
+                HorizontalOptions="Center"
+                VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="20" />
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="12">
+                    <Label
+                        FontSize="26"
+                        HorizontalTextAlignment="Center"
+                        Style="{StaticResource TitleLabel}"
+                        Text="Der Trail ist überrannt! 🦟" />
+                    <Label
+                        FontSize="13"
+                        HorizontalTextAlignment="Center"
+                        Style="{StaticResource SubtitleLabel}"
+                        Text="{Binding ResultLabel}" />
+                    <Button Command="{Binding RestartCommand}" Text="🔄 Neue Runde" />
+                </VerticalStackLayout>
+            </Border>
+        </Grid>
+
+        <!-- Bottom panel: wave button + hint + tower shop -->
+        <VerticalStackLayout Grid.Row="2" Padding="16,8,16,16" Spacing="8">
+
+            <Border Padding="14,10" IsVisible="{Binding CanStartWave}" Style="{StaticResource CardBorder}">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding StartWaveCommand}" />
+                </Border.GestureRecognizers>
+                <Label
+                    HorizontalTextAlignment="Center"
+                    Style="{StaticResource TitleLabel}"
+                    Text="{Binding WaveLabel, StringFormat='▶ {0} starten'}" />
+                <Border.Triggers>
+                    <DataTrigger Binding="{Binding CanStartWave}" TargetType="Border" Value="True">
+                        <Setter Property="Stroke" Value="{StaticResource Accent}" />
+                    </DataTrigger>
+                </Border.Triggers>
+            </Border>
+
+            <Label
+                FontSize="12"
+                HorizontalTextAlignment="Center"
+                Style="{StaticResource SubtitleLabel}"
+                Text="{Binding ModeHint}" />
+
+            <ScrollView HorizontalScrollBarVisibility="Never" Orientation="Horizontal">
+                <HorizontalStackLayout Spacing="10" BindableLayout.ItemsSource="{Binding ShopItems}">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:TowerShopItemViewModel">
+                            <Border Padding="12,8" Style="{StaticResource CardBorder}" WidthRequest="92">
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:TowerDefensePageViewModel}}, Path=SelectTowerCommand}" CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                                <VerticalStackLayout Spacing="2">
+                                    <Label FontSize="24" HorizontalTextAlignment="Center" Text="{Binding Icon}" />
+                                    <Label
+                                        FontSize="11"
+                                        HorizontalTextAlignment="Center"
+                                        Style="{StaticResource TitleLabel}"
+                                        Text="{Binding Name}" />
+                                    <Label
+                                        FontSize="10"
+                                        HorizontalTextAlignment="Center"
+                                        IsVisible="{Binding IsUnlocked}"
+                                        Style="{StaticResource StatLabel}"
+                                        Text="{Binding EnergyCost, StringFormat='{0} ⚡'}" />
+                                    <Label
+                                        FontSize="9"
+                                        HorizontalTextAlignment="Center"
+                                        IsVisible="{Binding IsUnlocked, Converter={mct:InvertedBoolConverter}}"
+                                        Style="{StaticResource StatLabel}"
+                                        Text="{Binding LockLabel}" />
+                                </VerticalStackLayout>
+                                <Border.Triggers>
+                                    <DataTrigger
+                                        Binding="{Binding Source={RelativeSource AncestorType={x:Type viewModels:TowerDefensePageViewModel}}, Path=SelectedTower.Id}"
+                                        TargetType="Border"
+                                        Value="{Binding Id}">
+                                        <Setter Property="BackgroundColor" Value="{StaticResource AccentSoft}" />
+                                        <Setter Property="Stroke" Value="{StaticResource Accent}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsUnlocked}" TargetType="Border" Value="False">
+                                        <Setter Property="Opacity" Value="0.45" />
+                                    </DataTrigger>
+                                </Border.Triggers>
+                            </Border>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </HorizontalStackLayout>
+            </ScrollView>
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml.cs
+++ b/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml.cs
@@ -1,0 +1,12 @@
+using UniTracks.ViewModels.Pages;
+
+namespace UniTracks.Maui.Views.Pages;
+
+public partial class TowerDefensePage : ContentPage
+{
+    public TowerDefensePage(TowerDefensePageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/UniTracks.Maui/App.xaml.cs
+++ b/UniTracks.Maui/App.xaml.cs
@@ -12,6 +12,7 @@ namespace UniTracks.Maui
 
             Routing.RegisterRoute(nameof(TripOverviewPage), typeof(TripOverviewPage));
             Routing.RegisterRoute(nameof(CityBuilderPage), typeof(CityBuilderPage));
+            Routing.RegisterRoute(nameof(TowerDefensePage), typeof(TowerDefensePage));
         }
 
         protected override Window CreateWindow(IActivationState? activationState)

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -11,7 +11,9 @@ using UniTracks.Maui.Services.Location;
 using UniTracks.Maui.Views.Controls.Popups;
 using UniTracks.Maui.Views.Pages;
 using UniTracks.Maui.Views.Pages.Tabs;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Persistence;
+using UniTracks.Games.TowerDefense.Persistence;
 using UniTracks.Models.Constants;
 using UniTracks.Services.Data;
 using UniTracks.Services.Game;
@@ -117,6 +119,8 @@ public static class MauiProgram
         services.AddSingleton<IActivityStatsSource>(sp => sp.GetRequiredService<ICoinService>());
         services.AddSingleton<ICityStore, CityStore>();
         services.AddSingleton<ICityBuilderService, CityBuilderService>();
+        services.AddSingleton<ITowerDefenseStore, TowerDefenseStore>();
+        services.AddSingleton<ITowerDefenseService, TowerDefenseService>();
         services.AddSingleton<IGameCatalogService, GameCatalogService>();
         services.AddSingleton<UniTracks.Services.ApplicationModel.IPermissions, UniTracks.Maui.Services.ApplicationModel.Permissions>();
         services.AddSingleton<UniTracks.Services.Dispatching.IDispatcher, UniTracks.Maui.Services.Dispatching.Dispatcher>();
@@ -157,6 +161,7 @@ public static class MauiProgram
         services.AddTransient<TripOverviewPage, TripOverviewViewModel>();
         services.AddTransient<GameTabPage, GameTabPageViewModel>();
         services.AddTransient<CityBuilderPage, CityBuilderPageViewModel>();
+        services.AddTransient<TowerDefensePage, TowerDefensePageViewModel>();
     }
 
     private static void RegisterPopups(IServiceCollection services)

--- a/UniTracks.Services/Game/CityBuilderService.cs
+++ b/UniTracks.Services/Game/CityBuilderService.cs
@@ -1,5 +1,6 @@
 using UniTracks.Games.CityBuilder;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Persistence;
 
 namespace UniTracks.Services.Game;
 

--- a/UniTracks.Services/Game/CityStore.cs
+++ b/UniTracks.Services/Game/CityStore.cs
@@ -1,5 +1,5 @@
 using UniTracks.Data.Repository;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.CityBuilder.Persistence;
 
 namespace UniTracks.Services.Game;
 

--- a/UniTracks.Services/Game/CoinService.cs
+++ b/UniTracks.Services/Game/CoinService.cs
@@ -1,5 +1,5 @@
 using UniTracks.Data.Repository;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.Shared.Persistence;
 using UniTracks.Models.Trip;
 using UniTracks.Services.Stats;
 

--- a/UniTracks.Services/Game/GameCatalogService.cs
+++ b/UniTracks.Services/Game/GameCatalogService.cs
@@ -1,18 +1,28 @@
 using UniTracks.Games.Catalog;
 using UniTracks.Games.CityBuilder;
-using UniTracks.Games.Economy;
-using UniTracks.Games.Persistence;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Economy;
+using UniTracks.Games.Shared.Persistence;
+using UniTracks.Games.TowerDefense;
+using UniTracks.Games.TowerDefense.Persistence;
 
 namespace UniTracks.Services.Game;
 
+/// <summary>
+/// Game registry plus the shared coin balance: coins are earned from activity and
+/// spent across all games (city buildings, expansions, tower unlocks) — always
+/// computed, never stored, so cross-game spending can never drift apart.
+/// </summary>
 public class GameCatalogService : IGameCatalogService
 {
     private readonly ICityStore cityStore;
+    private readonly ITowerDefenseStore towerDefenseStore;
     private readonly IActivityStatsSource activityStats;
 
-    public GameCatalogService(ICityStore cityStore, IActivityStatsSource activityStats)
+    public GameCatalogService(ICityStore cityStore, ITowerDefenseStore towerDefenseStore, IActivityStatsSource activityStats)
     {
         this.cityStore = cityStore;
+        this.towerDefenseStore = towerDefenseStore;
         this.activityStats = activityStats;
     }
 
@@ -23,7 +33,11 @@ public class GameCatalogService : IGameCatalogService
         var stats = await activityStats.GetAsync();
         var placed = await cityStore.LoadAsync();
         var expansions = await cityStore.LoadExpansionsAsync();
+        var unlocks = await towerDefenseStore.LoadUnlocksAsync();
         int earned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements);
-        return Math.Max(0, earned - CityEngine.ComputeSpent(placed) - CityEngine.ComputeExpansionSpent(expansions));
+        int spent = CityEngine.ComputeSpent(placed)
+            + CityEngine.ComputeExpansionSpent(expansions)
+            + DefenseEngine.ComputeUnlockSpent(unlocks);
+        return Math.Max(0, earned - spent);
     }
 }

--- a/UniTracks.Services/Game/ICoinService.cs
+++ b/UniTracks.Services/Game/ICoinService.cs
@@ -1,4 +1,4 @@
-using UniTracks.Games.Persistence;
+using UniTracks.Games.Shared.Persistence;
 
 namespace UniTracks.Services.Game;
 

--- a/UniTracks.Services/Game/ITowerDefenseService.cs
+++ b/UniTracks.Services/Game/ITowerDefenseService.cs
@@ -1,0 +1,20 @@
+using UniTracks.Games.TowerDefense;
+
+namespace UniTracks.Services.Game;
+
+/// <summary>
+/// Coordinates the trail-defense game: persistent profile (coins, unlocks, best result),
+/// coin-validated tower unlocks and highscore bookkeeping. The run simulation itself
+/// is pure engine (<see cref="DefenseEngine"/>) and lives in the view layer.
+/// </summary>
+public interface ITowerDefenseService
+{
+    /// <summary>Loads the persistent profile: spendable coins, unlocked towers, best result.</summary>
+    Task<DefenseProfile> GetProfileAsync();
+
+    /// <summary>Unlocks a tower permanently if it is known, new and affordable with coins.</summary>
+    Task<UnlockResult> TryUnlockAsync(string towerId);
+
+    /// <summary>Persists a finished run when it beats the stored best wave or score.</summary>
+    Task<DefenseProfile> SaveRunResultAsync(int clearedWave, int score);
+}

--- a/UniTracks.Services/Game/TowerDefenseService.cs
+++ b/UniTracks.Services/Game/TowerDefenseService.cs
@@ -1,0 +1,79 @@
+using UniTracks.Games.TowerDefense;
+using UniTracks.Games.TowerDefense.Persistence;
+
+namespace UniTracks.Services.Game;
+
+public class TowerDefenseService : ITowerDefenseService
+{
+    private readonly ITowerDefenseStore store;
+    private readonly IGameCatalogService gameCatalogService;
+
+    public TowerDefenseService(ITowerDefenseStore store, IGameCatalogService gameCatalogService)
+    {
+        this.store = store;
+        this.gameCatalogService = gameCatalogService;
+    }
+
+    public async Task<DefenseProfile> GetProfileAsync()
+    {
+        var unlocks = await store.LoadUnlocksAsync();
+        var record = await store.LoadRecordAsync();
+
+        return new DefenseProfile
+        {
+            Coins = await gameCatalogService.GetCoinBalanceAsync(),
+            UnlockedTowerIds = unlocks.Select(u => u.TowerId).ToList(),
+            BestWave = record?.BestWave ?? 0,
+            BestScore = record?.BestScore ?? 0,
+        };
+    }
+
+    public async Task<UnlockResult> TryUnlockAsync(string towerId)
+    {
+        var tower = TowerCatalog.Find(towerId);
+        if (tower is null)
+        {
+            return UnlockResult.Fail("Unbekannter Turm.");
+        }
+
+        var unlocks = await store.LoadUnlocksAsync();
+        if (unlocks.Any(u => u.TowerId == towerId))
+        {
+            return UnlockResult.Fail("Dieser Turm ist bereits freigeschaltet.");
+        }
+
+        int coins = await gameCatalogService.GetCoinBalanceAsync();
+        if (coins < tower.UnlockCost)
+        {
+            return UnlockResult.Fail($"Nicht genug Münzen — dir fehlen {tower.UnlockCost - coins:N0} 🪙.");
+        }
+
+        await store.SaveUnlockAsync(new TowerUnlock
+        {
+            ID = Guid.NewGuid(),
+            TowerId = towerId,
+            PurchasedAt = DateTimeOffset.UtcNow,
+        });
+
+        return UnlockResult.Ok();
+    }
+
+    public async Task<DefenseProfile> SaveRunResultAsync(int clearedWave, int score)
+    {
+        var record = await store.LoadRecordAsync();
+        if (record is null)
+        {
+            record = new DefenseRecord { ID = Guid.NewGuid() };
+        }
+
+        if (clearedWave > record.BestWave || score > record.BestScore)
+        {
+            record.BestWave = Math.Max(record.BestWave, clearedWave);
+            record.BestScore = Math.Max(record.BestScore, score);
+            record.UpdatedAt = DateTimeOffset.UtcNow;
+            await store.SaveRecordAsync(record);
+        }
+
+        return await GetProfileAsync();
+    }
+}

--- a/UniTracks.Services/Game/TowerDefenseService.cs
+++ b/UniTracks.Services/Game/TowerDefenseService.cs
@@ -36,6 +36,11 @@ public class TowerDefenseService : ITowerDefenseService
             return UnlockResult.Fail("Unbekannter Turm.");
         }
 
+        if (tower.IsFree)
+        {
+            return UnlockResult.Ok();
+        }
+
         var unlocks = await store.LoadUnlocksAsync();
         if (unlocks.Any(u => u.TowerId == towerId))
         {

--- a/UniTracks.Services/Game/TowerDefenseStore.cs
+++ b/UniTracks.Services/Game/TowerDefenseStore.cs
@@ -1,0 +1,28 @@
+using UniTracks.Data.Repository;
+using UniTracks.Games.TowerDefense.Persistence;
+
+namespace UniTracks.Services.Game;
+
+/// <summary>
+/// Implements the trail-defense persistence port on top of the provider-agnostic
+/// repository (EF Core + SQLite on most platforms, LiteDB on iOS).
+/// </summary>
+public class TowerDefenseStore : ITowerDefenseStore
+{
+    private readonly IRepository repository;
+
+    public TowerDefenseStore(IRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task<IReadOnlyList<TowerUnlock>> LoadUnlocksAsync() =>
+        (await repository.GetAllAsync<TowerUnlock>()).ToList();
+
+    public Task SaveUnlockAsync(TowerUnlock unlock) => repository.Add(unlock);
+
+    public async Task<DefenseRecord?> LoadRecordAsync() =>
+        (await repository.GetAllAsync<DefenseRecord>()).FirstOrDefault();
+
+    public Task SaveRecordAsync(DefenseRecord record) => repository.Update(record);
+}

--- a/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
@@ -1,0 +1,235 @@
+using System.Collections.ObjectModel;
+using AgredoApplication.MVVM.Services.Abstractions.UI;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using UniTracks.Games.TowerDefense;
+using UniTracks.Services.Game;
+
+namespace UniTracks.ViewModels.Pages;
+
+public partial class TowerDefensePageViewModel : ObservableObject
+{
+    private readonly ITowerDefenseService towerDefenseService;
+    private readonly IDialogService dialogService;
+
+    /// <summary>Guards against saving the same finished run twice.</summary>
+    private bool runSaved;
+
+    public TowerDefensePageViewModel(ITowerDefenseService towerDefenseService, IDialogService dialogService)
+    {
+        this.towerDefenseService = towerDefenseService;
+        this.dialogService = dialogService;
+
+        _ = LoadAsync();
+    }
+
+    /// <summary>Shop entries in catalog order (cheapest first), rebuilt with unlock state on every profile refresh.</summary>
+    public ObservableCollection<TowerShopItemViewModel> ShopItems { get; } = new();
+
+    /// <summary>The active run. Mutated in place by <see cref="DefenseEngine.Tick"/>; replaced on restart.</summary>
+    [ObservableProperty]
+    private DefenseState state = DefenseEngine.NewRun(Array.Empty<string>());
+
+    [ObservableProperty]
+    private DefenseProfile profile = new();
+
+    [ObservableProperty]
+    private TowerDefinition? selectedTower;
+
+    [ObservableProperty]
+    private bool isSellMode;
+
+    [ObservableProperty]
+    private string coinsLabel = "0 🪙";
+
+    [ObservableProperty]
+    private string energyLabel = "0 ⚡";
+
+    [ObservableProperty]
+    private string livesLabel = "20 ❤️";
+
+    [ObservableProperty]
+    private string waveLabel = "Welle 1";
+
+    [ObservableProperty]
+    private string bestLabel = string.Empty;
+
+    /// <summary>Whether the next wave can be started right now (between waves).</summary>
+    [ObservableProperty]
+    private bool canStartWave = true;
+
+    /// <summary>Whether the run is over (drives the game-over overlay).</summary>
+    [ObservableProperty]
+    private bool isLost;
+
+    /// <summary>Summary line shown on the game-over overlay.</summary>
+    [ObservableProperty]
+    private string resultLabel = string.Empty;
+
+    [ObservableProperty]
+    private string modeHint = "Wähle einen Turm und tippe auf ein freies Feld.";
+
+    partial void OnSelectedTowerChanged(TowerDefinition? value)
+    {
+        if (value is not null)
+        {
+            IsSellMode = false;
+            ModeHint = $"{value.Icon} {value.Name} ({value.EnergyCost} ⚡) — tippe auf ein freies Feld.";
+        }
+        else if (!IsSellMode)
+        {
+            ModeHint = "Wähle einen Turm und tippe auf ein freies Feld.";
+        }
+    }
+
+    partial void OnIsSellModeChanged(bool value)
+    {
+        if (value)
+        {
+            SelectedTower = null;
+            ModeHint = "💥 Verkaufen: tippe auf einen Turm (50 % Rückerstattung).";
+        }
+        else if (SelectedTower is null)
+        {
+            ModeHint = "Wähle einen Turm und tippe auf ein freies Feld.";
+        }
+    }
+
+    [RelayCommand]
+    private async Task SelectTower(TowerShopItemViewModel? item)
+    {
+        if (item is null)
+        {
+            return;
+        }
+
+        if (!item.IsUnlocked)
+        {
+            await UnlockAsync(item);
+            return;
+        }
+
+        // Tapping the active tower again deselects it.
+        SelectedTower = SelectedTower?.Id == item.Id ? null : item.Tower;
+    }
+
+    [RelayCommand]
+    private void ToggleSellMode()
+    {
+        IsSellMode = !IsSellMode;
+    }
+
+    [RelayCommand]
+    private async Task TileTapped(DefenseTile? tile)
+    {
+        if (tile is null || IsLost)
+        {
+            return;
+        }
+
+        DefenseResult result = IsSellMode
+            ? DefenseEngine.SellTower(State, tile.X, tile.Y)
+            : SelectedTower is not null
+                ? DefenseEngine.PlaceTower(State, SelectedTower.Id, tile.X, tile.Y)
+                : DefenseResult.Fail(DefenseError.TileEmpty);
+
+        if (!result.Success && result.Error != DefenseError.TileEmpty)
+        {
+            await dialogService.AlertAsync("Hinweis", result.ErrorMessage, "OK");
+        }
+
+        RefreshLabels();
+    }
+
+    [RelayCommand]
+    private void StartWave()
+    {
+        DefenseEngine.StartWave(State);
+        RefreshLabels();
+    }
+
+    /// <summary>Advances the simulation — wired to the map view's animation timer.</summary>
+    [RelayCommand]
+    private async Task Tick(int elapsedMs)
+    {
+        DefenseEngine.Tick(State, elapsedMs);
+        RefreshLabels();
+
+        if (State.Phase == DefensePhase.Lost && !runSaved)
+        {
+            runSaved = true;
+            ApplyProfile(await towerDefenseService.SaveRunResultAsync(State.ClearedWave, State.Score));
+        }
+    }
+
+    [RelayCommand]
+    private void Restart()
+    {
+        State = DefenseEngine.NewRun(Profile.UnlockedTowerIds);
+        runSaved = false;
+        IsLost = false;
+        SelectedTower = null;
+        IsSellMode = false;
+        RefreshLabels();
+    }
+
+    [RelayCommand]
+    private async Task Refresh()
+    {
+        await LoadAsync();
+    }
+
+    private async Task UnlockAsync(TowerShopItemViewModel item)
+    {
+        var result = await towerDefenseService.TryUnlockAsync(item.Id);
+        if (!result.Success)
+        {
+            await dialogService.AlertAsync("Gesperrt", result.ErrorMessage, "OK");
+            return;
+        }
+
+        ApplyProfile(await towerDefenseService.GetProfileAsync());
+        SelectedTower = item.Tower;
+    }
+
+    private async Task LoadAsync()
+    {
+        var profile = await towerDefenseService.GetProfileAsync();
+        ApplyProfile(profile);
+
+        // First load starts the run with the player's unlocked towers.
+        State = DefenseEngine.NewRun(profile.UnlockedTowerIds);
+        runSaved = false;
+        IsLost = false;
+        RefreshLabels();
+    }
+
+    private void ApplyProfile(DefenseProfile profile)
+    {
+        Profile = profile;
+        CoinsLabel = $"{profile.Coins:N0} 🪙";
+        BestLabel = profile.BestWave > 0
+            ? $"Rekord: Welle {profile.BestWave} · {profile.BestScore:N0} Punkte"
+            : "Noch kein Rekord — starte deine erste Welle!";
+
+        SelectedTower = null;
+        ShopItems.Clear();
+        foreach (var tower in TowerCatalog.Towers)
+        {
+            ShopItems.Add(new TowerShopItemViewModel(tower, profile));
+        }
+    }
+
+    private void RefreshLabels()
+    {
+        EnergyLabel = $"{State.Energy:N0} ⚡";
+        LivesLabel = $"{State.Lives} ❤️";
+        WaveLabel = $"Welle {State.NextWave}";
+        CanStartWave = State.Phase == DefensePhase.Building;
+        IsLost = State.Phase == DefensePhase.Lost;
+        if (IsLost)
+        {
+            ResultLabel = $"Geschaffte Wellen: {State.ClearedWave} · Punkte: {State.Score:N0}";
+        }
+    }
+}

--- a/UniTracks.ViewModels/Pages/TowerShopItemViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TowerShopItemViewModel.cs
@@ -1,0 +1,39 @@
+using UniTracks.Games.TowerDefense;
+
+namespace UniTracks.ViewModels.Pages;
+
+/// <summary>
+/// Shop entry wrapping a tower definition with its current unlock state,
+/// so the UI can grey out coin-gated towers.
+/// </summary>
+public class TowerShopItemViewModel
+{
+    public TowerShopItemViewModel(TowerDefinition tower, DefenseProfile profile)
+    {
+        Tower = tower;
+        IsUnlocked = tower.UnlockCost == 0 || profile.UnlockedTowerIds.Contains(tower.Id);
+        IsAffordable = profile.Coins >= tower.UnlockCost;
+
+        LockLabel = IsUnlocked ? string.Empty : $"🔒 {tower.UnlockCost:N0} 🪙";
+    }
+
+    public TowerDefinition Tower { get; }
+
+    public string Id => Tower.Id;
+
+    public string Icon => Tower.Icon;
+
+    public string Name => Tower.Name;
+
+    /// <summary>In-run energy price shown on unlocked towers.</summary>
+    public int EnergyCost => Tower.EnergyCost;
+
+    /// <summary>Permanently unlocked (starter tower or purchased with coins).</summary>
+    public bool IsUnlocked { get; }
+
+    /// <summary>Enough coins for the unlock purchase.</summary>
+    public bool IsAffordable { get; }
+
+    /// <summary>Unlock price shown on locked items ("" when unlocked).</summary>
+    public string LockLabel { get; }
+}

--- a/UniTracks.ViewModels/Pages/TowerShopItemViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TowerShopItemViewModel.cs
@@ -11,7 +11,7 @@ public class TowerShopItemViewModel
     public TowerShopItemViewModel(TowerDefinition tower, DefenseProfile profile)
     {
         Tower = tower;
-        IsUnlocked = tower.UnlockCost == 0 || profile.UnlockedTowerIds.Contains(tower.Id);
+        IsUnlocked = tower.IsFree || profile.UnlockedTowerIds.Contains(tower.Id);
         IsAffordable = profile.Coins >= tower.UnlockCost;
 
         LockLabel = IsUnlocked ? string.Empty : $"🔒 {tower.UnlockCost:N0} 🪙";


### PR DESCRIPTION
## Zusammenfassung

Neues Tower-Defense-Spiel **Trail Defense** (verteidige deinen Trail gegen Mücken) plus Umstrukturierung von `UniTracks.Games` auf eine Ordnerstruktur pro Spiel.

### Neues Spiel: Trail Defense 🦟🛡️
- **Engine** (`UniTracks.Games/TowerDefense/`): reine C#-Spiellogik – Turm-Katalog, Wellen-System, Pfad-Logik, Simulations-Engine, Persistenz-Ports
- **Isometrische Karte** (`DefenseMapView`): Perspektive wie im CityBuilder – Diamant-Tiles mit 3D-Seitenflächen, Painter's Algorithm, Pan/Pinch-Zoom, Range-Vorschau, Gegner mit HP-Balken
- **UI**: `TowerDefensePage` + ViewModels, Turm-Shop mit Münz-Integration
- **Wirtschaft**: Startturm „Mückenspray" kostenlos platzierbar (`TowerDefinition.IsFree`), weitere Türme per Münzen freischaltbar; Ausgaben werden in die Münz-Bilanz eingerechnet
- **Persistenz**: EF-Migration `TowerDefense` (Tabellen `TowerUnlocks`, `DefenseRecords`)

### Umstrukturierung UniTracks.Games
- Jedes Spiel bekommt einen eigenen Ordner: `CityBuilder/`, `TowerDefense/`, `Shared/`
- Shared: `Shared/Economy/`, `Shared/Persistence/`; CityBuilder-Persistenz nach `CityBuilder/Persistence/`
- Namespaces in Games/Services/Data/Maui entsprechend angepasst

### Infrastruktur
- DI-Registrierung + Route für die Spielseite
- DbSets in `SqliteDBContext`
- README: Ordnerstruktur der Spiele dokumentiert

### Validierung
- Alle Projekte + MAUI-App (Windows + Android) bauen fehlerfrei
- Auf SHIFTphone 8 (Android 14) deployed und getestet