### PR TITLE
Trip types: iOS-Seeding beheben + Lupe-Such-Popup

### DIFF
--- a/UniTracks.Data/SQLite/SqliteDBContext.cs
+++ b/UniTracks.Data/SQLite/SqliteDBContext.cs
@@ -1,8 +1,7 @@
 using System.Data;
 using System.Linq;
-using System.Reflection;
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using UniTracks.Data.Seeding;
 using UniTracks.Games.CityBuilder.Persistence;
 using UniTracks.Games.TowerDefense.Persistence;
 using UniTracks.Models.Constants;
@@ -81,20 +80,7 @@ public class SqliteDBContext : DbContext
     /// <summary>
     /// Reads the embedded <c>Data/triptypes.json</c> seed catalog into <see cref="TripType"/> instances.
     /// </summary>
-    private static List<TripType> LoadTripTypeSeeds()
-    {
-        var assembly = typeof(SqliteDBContext).Assembly;
-        var resourceName = assembly.GetManifestResourceNames()
-            .FirstOrDefault(n => n.EndsWith("triptypes.json", StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException(
-                $"Embedded resource 'triptypes.json' not found in assembly {assembly.FullName}.");
-
-        using var stream = assembly.GetManifestResourceStream(resourceName)!;
-        using var reader = new StreamReader(stream);
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        return JsonSerializer.Deserialize<List<TripType>>(reader.ReadToEnd(), options)
-            ?? new List<TripType>();
-    }
+    private static List<TripType> LoadTripTypeSeeds() => TripTypeSeeds.Load();
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/UniTracks.Data/Seeding/DatabaseInitializer.cs
+++ b/UniTracks.Data/Seeding/DatabaseInitializer.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using UniTracks.Data.Repository;
+using UniTracks.Models.Trip;
+
+namespace UniTracks.Data.Seeding;
+
+/// <summary>
+/// Seeds the active repository with the TripType catalog when it is empty. This is required on
+/// iOS where the store is LiteDB and there is no EF Core HasData/migration seeding; on Android,
+/// Mac Catalyst and Windows the repository is already seeded by EF migrations, so this is a no-op.
+/// </summary>
+public class DatabaseInitializer
+{
+    private readonly IRepository _repository;
+    private bool _seeded;
+
+    public DatabaseInitializer(IRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task EnsureSeededAsync()
+    {
+        if (_seeded)
+            return;
+
+        try
+        {
+            if (!(await _repository.GetAllAsync<TripType>()).Any())
+            {
+                foreach (var tripType in TripTypeSeeds.Load())
+                {
+                    await _repository.Add(tripType);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Best-effort seeding: a failure must never prevent app startup.
+            Debug.WriteLine($"DatabaseInitializer: TripType seeding failed: {ex}");
+            _seeded = false;
+            return;
+        }
+
+        _seeded = true;
+    }
+}

--- a/UniTracks.Data/Seeding/TripTypeSeeds.cs
+++ b/UniTracks.Data/Seeding/TripTypeSeeds.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using System.Text.Json;
+using UniTracks.Models.Trip;
+
+namespace UniTracks.Data.Seeding;
+
+/// <summary>
+/// Loads the embedded <c>Data/triptypes.json</c> seed catalog. This is shared by the EF Core
+/// <see cref="UniTracks.Data.SQLite.SqliteDBContext"/> (via HasData) and by the cross-platform
+/// <see cref="DatabaseInitializer"/>, so the catalog is available on every platform — including
+/// iOS, where the store is LiteDB and EF Core's HasData/migration seeding is skipped.
+/// </summary>
+public static class TripTypeSeeds
+{
+    public static List<TripType> Load()
+    {
+        var assembly = typeof(TripTypeSeeds).Assembly;
+        var resourceName = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith("triptypes.json", StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException(
+                $"Embedded resource 'triptypes.json' not found in assembly {assembly.FullName}.");
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+
+        // Parse with JsonDocument rather than reflection-based JsonSerializer.Deserialize: on iOS
+        // (IsDynamicCodeSupported=false) reflection-based serialization is not available, so a
+        // source-friendly manual read keeps the seed working under AOT / ReadyToRun.
+        using var document = JsonDocument.Parse(reader.ReadToEnd());
+        var result = new List<TripType>();
+        foreach (var element in document.RootElement.EnumerateArray())
+        {
+            result.Add(new TripType
+            {
+                ID = element.GetProperty("ID").GetGuid(),
+                Name = element.GetProperty("Name").GetString() ?? string.Empty,
+                Identifier = element.GetProperty("Identifier").GetString() ?? string.Empty,
+                Description = element.GetProperty("Description").GetString() ?? string.Empty,
+                Category = element.GetProperty("Category").GetString() ?? string.Empty,
+            });
+        }
+
+        return result;
+    }
+}

--- a/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml
+++ b/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup
+    x:Class="UniTracks.Maui.Views.Controls.Popups.TripTypeSearchPopup"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:vm="clr-namespace:UniTracks.ViewModels.Controls.Popups;assembly=UniTracks.ViewModels"
+    xmlns:models="clr-namespace:UniTracks.Models.Trip;assembly=UniTracks.Models"
+    x:DataType="vm:TripTypeSearchPopupViewModel"
+    BackgroundColor="Transparent"
+    CanBeDismissedByTappingOutsideOfPopup="True">
+
+    <toolkit:Popup.Resources>
+        <Style x:Key="FieldBorder" TargetType="Border">
+            <Setter Property="BackgroundColor" Value="{StaticResource CardAlt}" />
+            <Setter Property="Stroke" Value="{StaticResource CardStroke}" />
+            <Setter Property="StrokeThickness" Value="1" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="StrokeShape">
+                <Setter.Value>
+                    <RoundRectangle CornerRadius="12" />
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </toolkit:Popup.Resources>
+
+    <Border
+        Padding="24"
+        Style="{StaticResource CardBorder}"
+        Stroke="Transparent"
+        StrokeThickness="0"
+        WidthRequest="420">
+        <VerticalStackLayout Spacing="12">
+
+            <Label Style="{StaticResource TitleLabel}" Text="Trip-Typ suchen" />
+            <Label
+                Style="{StaticResource SubtitleLabel}"
+                Text="Tippe einen Typ an, um ihn auszuwählen." />
+
+            <Border Style="{StaticResource FieldBorder}">
+                <Entry
+                    Placeholder="Suchen..."
+                    Text="{Binding SearchText}" />
+            </Border>
+
+            <CollectionView
+                HeightRequest="320"
+                ItemsSource="{Binding Types}"
+                SelectionMode="None">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:TripType">
+                        <Border
+                            Margin="0,4"
+                            Padding="16,12"
+                            Stroke="{StaticResource CardStroke}"
+                            StrokeThickness="1">
+                            <Border.StrokeShape>
+                                <RoundRectangle CornerRadius="12" />
+                            </Border.StrokeShape>
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnTypeTapped" />
+                            </Border.GestureRecognizers>
+                            <Label
+                                FontSize="14"
+                                Text="{Binding Name}"
+                                TextColor="{StaticResource TextSecondary}" />
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Button
+                Command="{Binding CancelCommand}"
+                Margin="0,8,0,0"
+                Style="{StaticResource SecondaryButton}"
+                Text="Abbrechen" />
+        </VerticalStackLayout>
+    </Border>
+</toolkit:Popup>

--- a/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Maui.Views;
+using UniTracks.Models.Trip;
+using UniTracks.ViewModels.Controls.Popups;
+
+namespace UniTracks.Maui.Views.Controls.Popups;
+
+public partial class TripTypeSearchPopup : Popup
+{
+	private readonly TripTypeSearchPopupViewModel _viewModel;
+
+	public TripTypeSearchPopup(TripTypeSearchPopupViewModel viewModel)
+	{
+		InitializeComponent();
+
+		BindingContext = viewModel;
+		_viewModel = viewModel;
+
+		_viewModel.Completed += OnCompleted;
+	}
+
+	private void OnCompleted(object? sender, TripType? type)
+	{
+		_viewModel.Completed -= OnCompleted;
+		MainThread.BeginInvokeOnMainThread(async () => await CloseAsync());
+	}
+
+	private void OnTypeTapped(object? sender, TappedEventArgs e)
+	{
+		if ((sender as BindableObject)?.BindingContext is TripType type)
+		{
+			_viewModel.SelectType(type);
+		}
+	}
+}

--- a/UniTracks.Maui.Views/Pages/Tabs/RecordTripTabPage.xaml
+++ b/UniTracks.Maui.Views/Pages/Tabs/RecordTripTabPage.xaml
@@ -66,15 +66,48 @@
         </Border>
 
         <!-- Trip type selector -->
-        <CollectionView
+        <Grid
             Grid.Row="1"
             Margin="0,20,0,0"
-            HeightRequest="56"
-            HorizontalScrollBarVisibility="Never"
-            ItemsSource="{Binding TripTypes}"
-            SelectedItem="{Binding SelectedTripType}"
-            SelectionMode="Single"
-            VerticalScrollBarVisibility="Never">
+            ColumnDefinitions="Auto,*"
+            ColumnSpacing="8">
+
+            <!-- Search (Lupe) -->
+            <Border
+                Grid.Column="0"
+                Padding="14,10"
+                Stroke="{StaticResource Accent}"
+                StrokeThickness="2"
+                VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="20" />
+                </Border.StrokeShape>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding SearchTripTypeCommand}" />
+                </Border.GestureRecognizers>
+                <HorizontalStackLayout Spacing="6">
+                    <Image
+                        HeightRequest="18"
+                        Source="search.png"
+                        VerticalOptions="Center"
+                        WidthRequest="18" />
+                    <Label
+                        FontAttributes="Bold"
+                        FontSize="12"
+                        Text="Suchen"
+                        TextColor="{StaticResource TextSecondary}"
+                        VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </Border>
+
+            <CollectionView
+                Grid.Column="1"
+                HeightRequest="56"
+                HorizontalScrollBarVisibility="Never"
+                ItemsSource="{Binding TripTypes}"
+                SelectedItem="{Binding SelectedTripType}"
+                SelectionMode="Single"
+                VerticalScrollBarVisibility="Never">
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout ItemSpacing="8" Orientation="Horizontal" />
             </CollectionView.ItemsLayout>
@@ -115,6 +148,7 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
+        </Grid>
 
         <!-- Timer -->
         <Label

--- a/UniTracks.Maui/App.xaml.cs
+++ b/UniTracks.Maui/App.xaml.cs
@@ -1,3 +1,4 @@
+using UniTracks.Data.Seeding;
 using UniTracks.Maui.Views;
 using UniTracks.Maui.Views.Pages;
 
@@ -5,11 +6,16 @@ namespace UniTracks.Maui
 {
     public partial class App : Application
     {
-        public App()
+        public App(DatabaseInitializer databaseInitializer)
         {
             HookUnhandledExceptionLogging();
 
             InitializeComponent();
+
+            // Seed the TripType catalog if the active repository is empty (relevant on iOS, where
+            // the store is LiteDB and there is no EF Core HasData/migration seeding). The call
+            // completes synchronously for both stores, so a short block here is safe.
+            databaseInitializer.EnsureSeededAsync().GetAwaiter().GetResult();
 
             MainPage = new AppShell();
 

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.LifecycleEvents;
 using SkiaSharp.Views.Maui.Controls.Hosting;
 using UniTracks.Data.LiteDB;
 using UniTracks.Data.Repository;
+using UniTracks.Data.Seeding;
 using UniTracks.Data.SQLite;
 using UniTracks.Maui.Services.Location;
 using UniTracks.Maui.Views.Controls.Popups;
@@ -35,7 +36,18 @@ public static class MauiProgram
 
         builder
             .UseMauiApp<App>()
-            .UseMauiCommunityToolkit()
+            .UseMauiCommunityToolkit(options =>
+            {
+                options.SetPopupOptionsDefaults(new DefaultPopupOptionsSettings
+                {
+                    Shape = new Microsoft.Maui.Controls.Shapes.RoundRectangle
+                    {
+                        CornerRadius = new CornerRadius(20, 20, 20, 20),
+                        StrokeThickness = 0,
+                        Stroke = new SolidColorBrush(Colors.Transparent),
+                    },
+                });
+            })
             .UseSkiaSharp()
             .ConfigureLifecycleEvents(events =>
             {
@@ -82,6 +94,11 @@ public static class MauiProgram
         RegisterAgredoServices(services);
         RegisterUniTracksServices(services);
         RegisterDataAccess(services);
+
+        // Seeds the active repository (EF Core SQLite or LiteDB) with the TripType catalog when
+        // empty. On iOS the store is LiteDB and receives its seed here; elsewhere it is a no-op.
+        services.AddSingleton<DatabaseInitializer>();
+
         RegisterPages(services);
         RegisterPopups(services);
 
@@ -169,5 +186,9 @@ public static class MauiProgram
         services.AddTransientPopup<UserCreationPopup, UserCreationPopupViewModel>();
         services.AddTransient<UserCreationPopupViewModel>();
         services.AddKeyedTransient<Popup, UserCreationPopup>(typeof(UserCreationPopupViewModel));
+
+        services.AddTransientPopup<TripTypeSearchPopup, TripTypeSearchPopupViewModel>();
+        services.AddTransient<TripTypeSearchPopupViewModel>();
+        services.AddKeyedTransient<Popup, TripTypeSearchPopup>(typeof(TripTypeSearchPopupViewModel));
     }
 }

--- a/UniTracks.Maui/Resources/Images/search.svg
+++ b/UniTracks.Maui/Resources/Images/search.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="216" cy="216" r="132" fill="none" stroke="#FFFFFF" stroke-width="52" />
+  <line x1="312" y1="312" x2="432" y2="432" stroke="#FFFFFF" stroke-width="52" stroke-linecap="round" />
+</svg>

--- a/UniTracks.ViewModels/Controls/Popups/TripTypeSearchPopupViewModel.cs
+++ b/UniTracks.ViewModels/Controls/Popups/TripTypeSearchPopupViewModel.cs
@@ -1,0 +1,71 @@
+using System.Collections.ObjectModel;
+using AgredoApplication.MVVM.Services.Abstractions.Navigation;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using UniTracks.Data.Repository;
+using UniTracks.Models.Trip;
+
+namespace UniTracks.ViewModels.Controls.Popups;
+
+public partial class TripTypeSearchPopupViewModel : ObservableObject, IPopupResultProvider<TripType?>
+{
+    public event EventHandler<TripType?>? Completed;
+
+    private List<TripType> allTypes = new();
+
+    public IRepository Repository { get; }
+
+    public ObservableCollection<TripType> Types { get; } = new();
+
+    [ObservableProperty]
+    private string searchText = string.Empty;
+
+    public TripTypeSearchPopupViewModel(IRepository repository)
+    {
+        Repository = repository;
+        _ = LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        allTypes = (await Repository.GetAllAsync<TripType>())
+            .OrderBy(t => t.Name)
+            .ToList();
+        ApplyFilter(SearchText);
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter(value);
+
+    private void ApplyFilter(string value)
+    {
+        Types.Clear();
+        IEnumerable<TripType> query = allTypes;
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            query = query.Where(t =>
+                t.Name.Contains(value, StringComparison.OrdinalIgnoreCase) ||
+                t.Identifier.Contains(value, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (var type in query)
+        {
+            Types.Add(type);
+        }
+    }
+
+    public void SelectType(TripType? type)
+    {
+        if (type is null)
+        {
+            return;
+        }
+
+        Completed?.Invoke(this, type);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Completed?.Invoke(this, null);
+    }
+}

--- a/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
@@ -102,6 +102,16 @@ public partial class RecordTripTabPageViewModel : ObservableObject
         OnPropertyChanged(nameof(IsTripTypeSelectionVisible));
     }
 
+    [RelayCommand]
+    private async Task SearchTripType()
+    {
+        var selected = await PopupNavigation.ShowPopupAsync<TripTypeSearchPopupViewModel, TripType?>();
+        if (selected is not null)
+        {
+            SelectedTripType = selected;
+        }
+    }
+
     partial void OnSelectedTripTypeChanged(TripType? value)
     {
         GpsDataStorageService.CurrentTripTypeId = value?.ID;


### PR DESCRIPTION
## Was

- **iOS-Seeding**: Der TripType-Katalog wird jetzt plattformübergreifend über `DatabaseInitializer` geseedet, falls der aktive Store leer ist. Das behebt die leere Typ-Liste auf iOS (Store dort ist LiteDB, EF `HasData`/Migration wird übersprungen).
- Die Seed-Ladung liegt nun in `TripTypeSeeds` (geteilt von SQLite + LiteDB) und nutzt `JsonDocument` statt reflection-basiertem `Deserialize` (iOS-AOT-freundlich).
- **Lupe als erstes Element der Trip-Typ-Liste**: öffnet ein Such-Popup mit Filter nach Name/Identifier und setzt den gewählten Typ (`SelectedTripType`).
- **Popup-Rand entfernt**: Der native graue CommunityToolkit-Popup-Rand (`DefaultPopupOptionsSettings.Shape`) ist jetzt ein randloser `RoundRectangle` — abgerundete Ecken und Schatten bleiben.

## Test

- Windows-Build: 0 Fehler, App geprüft (Popup randlos).
- Android self-contained APK: 0 Fehler, auf Gerät installiert und gestartet (MainActivity resumed, kein Crash).
- iOS: Seeding via `DatabaseInitializer` (JsonDocument, AOT-sicher).