### PR TITLE
Hintergrund-Location nativ für Android/iOS (Foreground-Service/CLLocationManager)

### DIFF
--- a/UniTracks.Maui.Services/Location/LocationService.cs
+++ b/UniTracks.Maui.Services/Location/LocationService.cs
@@ -1,80 +1,35 @@
-using IGeolocation = AgredoApplication.MVVM.Services.Abstractions.Devices.IGeolocation;
-using GeolocationRequest = AgredoApplication.MVVM.Services.Models.Devices.GeolocationRequest;
-using GeolocationAccuracy = AgredoApplication.MVVM.Services.Models.Devices.GeolocationAccuracy;
-using SharedLocation = AgredoApplication.MVVM.Services.Models.Devices.Location;
 using UniTracks.Models.GPS;
-using UniTracks.Services.Data;
 using UniTracks.Services.Location;
 
 namespace UniTracks.Maui.Services.Location;
 
+/// <summary>
+/// Thin platform-neutral coordinator. The platform-specific background capture lives in
+/// <see cref="IBackgroundLocationController"/>, keeping Android/iOS concerns out of the app layer.
+/// </summary>
 public class LocationService : ILocationService
 {
-    private readonly IGeolocation geolocation;
-    private readonly IGpsDataStorageService gpsDataStorageService;
-    private CancellationTokenSource? listeningCts;
+    private readonly IBackgroundLocationController controller;
 
-    public LocationService(IGeolocation geolocation, IGpsDataStorageService gpsDataStorageService)
+    public LocationService(IBackgroundLocationController controller)
     {
-        this.geolocation = geolocation;
-        this.gpsDataStorageService = gpsDataStorageService;
+        this.controller = controller;
     }
 
-    public Task StartListening(Action<GPSInformatoion> action) => StartListeningCoreAsync(action);
+    public Task StartListening(Action<GPSInformatoion> action)
+    {
+        controller.Start(action);
+        return Task.CompletedTask;
+    }
 
-    public Task StartListening() => StartListeningCoreAsync(null);
+    public Task StartListening()
+    {
+        controller.Start(null);
+        return Task.CompletedTask;
+    }
 
     public void StopListening()
     {
-        listeningCts?.Cancel();
-        listeningCts?.Dispose();
-        listeningCts = null;
-    }
-
-    private async Task StartListeningCoreAsync(Action<GPSInformatoion>? action)
-    {
-        StopListening();
-
-        var cts = new CancellationTokenSource();
-        listeningCts = cts;
-
-        var request = new GeolocationRequest
-        {
-            DesiredAccuracy = GeolocationAccuracy.Best,
-            Timeout = TimeSpan.FromSeconds(10)
-        };
-
-        try
-        {
-            while (!cts.Token.IsCancellationRequested)
-            {
-                SharedLocation? location = await geolocation.GetLocationAsync(request);
-                if (location is not null)
-                {
-                    var information = ToGpsInformation(location);
-                    action?.Invoke(information);
-                    await gpsDataStorageService.StoreData(information);
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Listener was stopped.
-        }
-    }
-
-    private static GPSInformatoion ToGpsInformation(SharedLocation location)
-    {
-        return new GPSInformatoion(
-            new Position(location.Longitude, location.Latitude),
-            location.Accuracy ?? 0,
-            location.Timestamp,
-            location.Course ?? 0,
-            0,
-            location.Altitude ?? 0,
-            location.Speed ?? 0,
-            0);
+        controller.Stop();
     }
 }

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -130,6 +130,14 @@ public static class MauiProgram
         services.AddSingleton<IGpsDataStorageService, GpsDataStorageService>();
         services.AddSingleton<IGamificationService, GamificationService>();
 
+#if ANDROID
+        services.AddSingleton<IBackgroundLocationController, BackgroundLocationController>();
+#elif IOS || MACCATALYST
+        services.AddSingleton<IBackgroundLocationController, BackgroundLocationController>();
+#else
+        services.AddSingleton<IBackgroundLocationController, BackgroundLocationController>();
+#endif
+
         // Games: coin economy + city builder. CoinService doubles as the games-layer
         // activity-stats port; the city store adapts the games persistence port to IRepository.
         services.AddSingleton<ICoinService, CoinService>();

--- a/UniTracks.Maui/Platforms/Android/AndroidManifest.xml
+++ b/UniTracks.Maui/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true">
+		<service android:name="com.agredoapplication.unitracks.BackgroundLocationService" android:exported="false" android:foregroundServiceType="location" />
+	</application>
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/UniTracks.Maui/Platforms/Android/BackgroundLocationController.cs
+++ b/UniTracks.Maui/Platforms/Android/BackgroundLocationController.cs
@@ -1,0 +1,29 @@
+using Android.App;
+using Android.Content;
+using AndroidX.Core.Content;
+using UniTracks.Models.GPS;
+using UniTracks.Services.Location;
+
+namespace UniTracks.Maui;
+
+/// <summary>
+/// Starts/stops the Android foreground location service. The app is foreground when the user
+/// taps record, so starting the service is allowed; once running it keeps capturing in the
+/// background with a persistent notification.
+/// </summary>
+public class BackgroundLocationController : IBackgroundLocationController
+{
+    public void Start(Action<GPSInformatoion>? onUpdate)
+    {
+        Context context = Android.App.Application.Context;
+        Intent intent = new(context, typeof(BackgroundLocationService));
+        ContextCompat.StartForegroundService(context, intent);
+    }
+
+    public void Stop()
+    {
+        Context context = Android.App.Application.Context;
+        Intent intent = new(context, typeof(BackgroundLocationService));
+        context.StopService(intent);
+    }
+}

--- a/UniTracks.Maui/Platforms/Android/BackgroundLocationService.cs
+++ b/UniTracks.Maui/Platforms/Android/BackgroundLocationService.cs
@@ -1,0 +1,183 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Locations;
+using Android.OS;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using UniTracks.Models.GPS;
+using UniTracks.Services.Data;
+using AndroidLocation = Android.Locations.Location;
+
+namespace UniTracks.Maui;
+
+/// <summary>
+/// Foreground service that keeps GPS recording alive while the app is in the background.
+/// Declared as a location foreground service in AndroidManifest.xml so the system keeps it
+/// running and does not throttle it in the background.
+/// </summary>
+public class BackgroundLocationService : Service
+{
+    private const string ChannelId = "unitracks.location";
+    private const int NotificationId = 0x554e4954; // 'UNIT'
+    private const long MinTimeMs = 1000L;
+    private const float MinDistanceMeters = 0f;
+
+    private LocationManager? locationManager;
+    private LocationListener? locationListener;
+    private IGpsDataStorageService? storage;
+    private bool isForeground;
+    private bool isUpdating;
+
+    public override void OnCreate()
+    {
+        base.OnCreate();
+
+        storage = IPlatformApplication.Current?.Services?.GetService<IGpsDataStorageService>();
+        locationManager = (LocationManager?)GetSystemService(Context.LocationService);
+        locationListener = new LocationListener(OnLocationReceived);
+    }
+
+    public override StartCommandResult OnStartCommand(Intent? intent, StartCommandFlags flags, int startId)
+    {
+        StartForegroundWithNotification();
+        StartLocationUpdates();
+        // Sticky: if the system kills us, it restarts us with the last intent.
+        return StartCommandResult.Sticky;
+    }
+
+    public override IBinder? OnBind(Intent? intent) => null;
+
+    public override void OnDestroy()
+    {
+        StopLocationUpdates();
+        base.OnDestroy();
+    }
+
+    private void StartForegroundWithNotification()
+    {
+        if (isForeground)
+        {
+            return;
+        }
+
+        NotificationManager? manager = (NotificationManager?)GetSystemService(Context.NotificationService);
+
+        if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+        {
+            var channel = new NotificationChannel(ChannelId, "Standort-Aufnahme", NotificationImportance.Low)
+            {
+                Description = "Hält die GPS-Aufnahme am Laufen, während die App im Hintergrund ist."
+            };
+            manager?.CreateNotificationChannel(channel);
+        }
+
+        Notification.Builder builder = Build.VERSION.SdkInt >= BuildVersionCodes.O
+            ? new Notification.Builder(this, ChannelId)
+            : new Notification.Builder(this);
+
+        Notification notification = builder
+            .SetContentTitle("UniTracks")
+            .SetContentText("Aufnahme läuft")
+            .SetSmallIcon(Android.Resource.Drawable.IcDialogInfo)
+            .SetOngoing(true)
+            .Build();
+
+        StartForeground(NotificationId, notification);
+        isForeground = true;
+    }
+
+    private void StartLocationUpdates()
+    {
+        if (isUpdating || locationManager is null || locationListener is null)
+        {
+            return;
+        }
+
+        try
+        {
+            // GPS first; emulators/indoors may not expose a GPS provider, so fall through.
+            locationManager.RequestLocationUpdates(
+                LocationManager.GpsProvider, MinTimeMs, MinDistanceMeters, locationListener, Looper.MainLooper);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UniTracks] GPS provider unavailable: {ex.Message}");
+        }
+
+        locationManager.RequestLocationUpdates(
+            LocationManager.NetworkProvider, MinTimeMs, MinDistanceMeters, locationListener, Looper.MainLooper);
+
+        isUpdating = true;
+    }
+
+    private void StopLocationUpdates()
+    {
+        locationManager?.RemoveUpdates(locationListener);
+        isUpdating = false;
+    }
+
+    private void OnLocationReceived(AndroidLocation location)
+    {
+        if (location is null)
+        {
+            return;
+        }
+
+        var information = new GPSInformatoion(
+            new Position(location.Longitude, location.Latitude),
+            location.Accuracy,
+            DateTimeOffset.FromUnixTimeMilliseconds(location.Time),
+            location.Bearing,
+            0,
+            location.Altitude,
+            location.Speed,
+            0);
+
+        _ = HandleLocationAsync(information);
+    }
+
+    private async Task HandleLocationAsync(GPSInformatoion information)
+    {
+        if (storage is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await storage.StoreData(information);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UniTracks] Background location store failed: {ex}");
+        }
+    }
+
+    private sealed class LocationListener : Java.Lang.Object, ILocationListener
+    {
+        private readonly Action<AndroidLocation> onLocation;
+
+        public LocationListener(Action<AndroidLocation> onLocation)
+        {
+            this.onLocation = onLocation;
+        }
+
+        public void OnLocationChanged(AndroidLocation location)
+        {
+            onLocation(location);
+        }
+
+        public void OnProviderDisabled(string provider)
+        {
+        }
+
+        public void OnProviderEnabled(string provider)
+        {
+        }
+
+        public void OnStatusChanged(string provider, Availability status, Bundle? extras)
+        {
+        }
+    }
+}

--- a/UniTracks.Maui/Platforms/MacCatalyst/BackgroundLocationController.cs
+++ b/UniTracks.Maui/Platforms/MacCatalyst/BackgroundLocationController.cs
@@ -1,0 +1,106 @@
+using CoreLocation;
+using Foundation;
+using UniTracks.Models.GPS;
+using UniTracks.Services.Data;
+using UniTracks.Services.Location;
+
+namespace UniTracks.Maui;
+
+/// <summary>
+/// MacCatalyst background location capture via CLLocationManager. Mirrors the iOS controller.
+/// </summary>
+public class BackgroundLocationController : IBackgroundLocationController
+{
+    private readonly IGpsDataStorageService storage;
+    private readonly CLLocationManager locationManager;
+    private readonly LocationDelegate locationDelegate;
+
+    public BackgroundLocationController(IGpsDataStorageService storage)
+    {
+        this.storage = storage;
+
+        locationManager = new CLLocationManager
+        {
+            DesiredAccuracy = CLLocation.AccuracyBest,
+            AllowsBackgroundLocationUpdates = true,
+            PausesLocationUpdatesAutomatically = false,
+            ActivityType = CLActivityType.Fitness,
+            DistanceFilter = 0
+        };
+
+        locationDelegate = new LocationDelegate(OnLocationReceived);
+    }
+
+    public void Start(Action<GPSInformatoion>? onUpdate)
+    {
+        locationManager.Delegate = locationDelegate;
+
+        if (CLLocationManager.LocationServicesEnabled)
+        {
+            locationManager.StartUpdatingLocation();
+        }
+    }
+
+    public void Stop()
+    {
+        locationManager.StopUpdatingLocation();
+        locationManager.Delegate = null;
+    }
+
+    private void OnLocationReceived(CLLocation location)
+    {
+        if (location is null)
+        {
+            return;
+        }
+
+        var information = new GPSInformatoion(
+            new Position(location.Coordinate.Longitude, location.Coordinate.Latitude),
+            location.HorizontalAccuracy,
+            ToDateTimeOffset(location.Timestamp),
+            location.Course,
+            0,
+            location.Altitude,
+            location.Speed,
+            0);
+
+        _ = StoreAsync(information);
+    }
+
+    private async Task StoreAsync(GPSInformatoion information)
+    {
+        try
+        {
+            await storage.StoreData(information);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UniTracks] MacCatalyst location store failed: {ex}");
+        }
+    }
+
+    private static DateTimeOffset ToDateTimeOffset(NSDate timestamp)
+    {
+        // NSDate's reference date is 2001-01-01T00:00:00Z.
+        return new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero)
+            .AddSeconds(timestamp.SecondsSinceReferenceDate);
+    }
+
+    private sealed class LocationDelegate : CLLocationManagerDelegate
+    {
+        private readonly Action<CLLocation> onLocation;
+
+        public LocationDelegate(Action<CLLocation> onLocation)
+        {
+            this.onLocation = onLocation;
+        }
+
+        public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)
+        {
+            foreach (CLLocation location in locations)
+            {
+                onLocation(location);
+            }
+        }
+    }
+}

--- a/UniTracks.Maui/Platforms/Windows/BackgroundLocationController.cs
+++ b/UniTracks.Maui/Platforms/Windows/BackgroundLocationController.cs
@@ -1,0 +1,85 @@
+using IGeolocation = AgredoApplication.MVVM.Services.Abstractions.Devices.IGeolocation;
+using GeolocationRequest = AgredoApplication.MVVM.Services.Models.Devices.GeolocationRequest;
+using GeolocationAccuracy = AgredoApplication.MVVM.Services.Models.Devices.GeolocationAccuracy;
+using SharedLocation = AgredoApplication.MVVM.Services.Models.Devices.Location;
+using UniTracks.Models.GPS;
+using UniTracks.Services.Data;
+using UniTracks.Services.Location;
+
+namespace UniTracks.Maui;
+
+/// <summary>
+/// Windows fallback. Desktop keeps the same get-location polling behaviour as before; a
+/// foreground/background service is not required on the desktop, so we just keep the loop.
+/// </summary>
+public class BackgroundLocationController : IBackgroundLocationController
+{
+    private readonly IGeolocation geolocation;
+    private readonly IGpsDataStorageService storage;
+    private CancellationTokenSource? listeningCts;
+
+    public BackgroundLocationController(IGeolocation geolocation, IGpsDataStorageService storage)
+    {
+        this.geolocation = geolocation;
+        this.storage = storage;
+    }
+
+    public void Start(Action<GPSInformatoion>? onUpdate)
+    {
+        _ = StartListeningCoreAsync(onUpdate);
+    }
+
+    public void Stop()
+    {
+        listeningCts?.Cancel();
+        listeningCts?.Dispose();
+        listeningCts = null;
+    }
+
+    private async Task StartListeningCoreAsync(Action<GPSInformatoion>? onUpdate)
+    {
+        Stop();
+
+        var cts = new CancellationTokenSource();
+        listeningCts = cts;
+
+        var request = new GeolocationRequest
+        {
+            DesiredAccuracy = GeolocationAccuracy.Best,
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+
+        try
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                SharedLocation? location = await geolocation.GetLocationAsync(request);
+                if (location is not null)
+                {
+                    var information = ToGpsInformation(location);
+                    onUpdate?.Invoke(information);
+                    await storage.StoreData(information);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Listener was stopped.
+        }
+    }
+
+    private static GPSInformatoion ToGpsInformation(SharedLocation location)
+    {
+        return new GPSInformatoion(
+            new Position(location.Longitude, location.Latitude),
+            location.Accuracy ?? 0,
+            location.Timestamp,
+            location.Course ?? 0,
+            0,
+            location.Altitude ?? 0,
+            location.Speed ?? 0,
+            0);
+    }
+}

--- a/UniTracks.Maui/Platforms/iOS/BackgroundLocationController.cs
+++ b/UniTracks.Maui/Platforms/iOS/BackgroundLocationController.cs
@@ -1,0 +1,108 @@
+using CoreLocation;
+using Foundation;
+using UniTracks.Models.GPS;
+using UniTracks.Services.Data;
+using UniTracks.Services.Location;
+
+namespace UniTracks.Maui;
+
+/// <summary>
+/// iOS/MacCatalyst background location capture via CLLocationManager. The app is authorized
+/// "Always" before recording starts; this manager keeps delivering updates when the app is
+/// backgrounded (UIBackgroundModes=location is set in Info.plist).
+/// </summary>
+public class BackgroundLocationController : IBackgroundLocationController
+{
+    private readonly IGpsDataStorageService storage;
+    private readonly CLLocationManager locationManager;
+    private readonly LocationDelegate locationDelegate;
+
+    public BackgroundLocationController(IGpsDataStorageService storage)
+    {
+        this.storage = storage;
+
+        locationManager = new CLLocationManager
+        {
+            DesiredAccuracy = CLLocation.AccuracyBest,
+            AllowsBackgroundLocationUpdates = true,
+            PausesLocationUpdatesAutomatically = false,
+            ActivityType = CLActivityType.Fitness,
+            DistanceFilter = 0
+        };
+
+        locationDelegate = new LocationDelegate(OnLocationReceived);
+    }
+
+    public void Start(Action<GPSInformatoion>? onUpdate)
+    {
+        locationManager.Delegate = locationDelegate;
+
+        if (CLLocationManager.LocationServicesEnabled)
+        {
+            locationManager.StartUpdatingLocation();
+        }
+    }
+
+    public void Stop()
+    {
+        locationManager.StopUpdatingLocation();
+        locationManager.Delegate = null;
+    }
+
+    private void OnLocationReceived(CLLocation location)
+    {
+        if (location is null)
+        {
+            return;
+        }
+
+        var information = new GPSInformatoion(
+            new Position(location.Coordinate.Longitude, location.Coordinate.Latitude),
+            location.HorizontalAccuracy,
+            ToDateTimeOffset(location.Timestamp),
+            location.Course,
+            0,
+            location.Altitude,
+            location.Speed,
+            0);
+
+        _ = StoreAsync(information);
+    }
+
+    private async Task StoreAsync(GPSInformatoion information)
+    {
+        try
+        {
+            await storage.StoreData(information);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UniTracks] iOS location store failed: {ex}");
+        }
+    }
+
+    private static DateTimeOffset ToDateTimeOffset(NSDate timestamp)
+    {
+        // NSDate's reference date is 2001-01-01T00:00:00Z.
+        return new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero)
+            .AddSeconds(timestamp.SecondsSinceReferenceDate);
+    }
+
+    private sealed class LocationDelegate : CLLocationManagerDelegate
+    {
+        private readonly Action<CLLocation> onLocation;
+
+        public LocationDelegate(Action<CLLocation> onLocation)
+        {
+            this.onLocation = onLocation;
+        }
+
+        public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)
+        {
+            foreach (CLLocation location in locations)
+            {
+                onLocation(location);
+            }
+        }
+    }
+}

--- a/UniTracks.Maui/Platforms/iOS/Info.plist
+++ b/UniTracks.Maui/Platforms/iOS/Info.plist
@@ -30,13 +30,13 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 
 	<key>NSLocationAlwaysUsageDescription</key>
-        <string>Say something useful here that your users will understand</string>
+        <string>UniTracks benötigt laufenden Zugriff auf deinen Standort, um Trips auch im Hintergrund aufzuzeichnen.</string>
         
         <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-        <string>Say something useful here that your users will understand</string>
+        <string>UniTracks verwendet den Standort, um deine Route aufzuzeichnen. Die Aufnahme läuft auch, wenn die App im Hintergrund ist.</string>
         
         <key>NSLocationWhenInUseUsageDescription</key>
-        <string>Say something useful here that your users will understand</string>
+        <string>UniTracks verwendet den Standort, um während der Aufnahme deine aktuelle Position zu erfassen.</string>
         
         <key>UIBackgroundModes</key>
         <array>

--- a/UniTracks.Services/Data/GpsDataStorageService.cs
+++ b/UniTracks.Services/Data/GpsDataStorageService.cs
@@ -92,6 +92,8 @@ public class GpsDataStorageService : IGpsDataStorageService
                 // Link the location to the tracked trip and update aggregates incrementally.
                 location.TripID = currentTrip.ID;
                 currentTrip.Locations.Add(location);
+                // Keep the trip end fresh so the duration (= EndTime - StartTime) is correct.
+                currentTrip.EndTime = DateTimeOffset.Now;
                 AccountFor(location);
                 ApplyAggregates(currentTrip);
 
@@ -109,6 +111,7 @@ public class GpsDataStorageService : IGpsDataStorageService
                 {
                     ID = Guid.NewGuid(),
                     StartTime = DateTimeOffset.Now,
+                    EndTime = DateTimeOffset.Now,
                     TripTypeId = CurrentTripTypeId,
                     Locations = new List<LocationModel>() { location }
                 };

--- a/UniTracks.Services/Location/IBackgroundLocationController.cs
+++ b/UniTracks.Services/Location/IBackgroundLocationController.cs
@@ -1,0 +1,17 @@
+using UniTracks.Models.GPS;
+
+namespace UniTracks.Services.Location;
+
+/// <summary>
+/// Platform-specific background location capture. Implementations keep recording while the app
+/// is not in the foreground (Android foreground service, iOS CLLocationManager). The change is
+/// deliberately abstracted so the app layer stays platform-agnostic.
+/// </summary>
+public interface IBackgroundLocationController
+{
+    /// <summary>Starts continuous location capture. <paramref name="onUpdate"/> is optional.</summary>
+    void Start(Action<GPSInformatoion>? onUpdate);
+
+    /// <summary>Stops location capture and releases resources.</summary>
+    void Stop();
+}


### PR DESCRIPTION
## Hintergrund-Location nativ implementieren

Die unzuverlässige Standort-Aufzeichnung im Hintergrund wurde durch eine plattformspezifische, native Implementierung (ohne Zusatzpaket) ersetzt.

### Änderungen
- **`IBackgroundLocationController`** — neue plattformneutrale Abstraktion als Saubere Kapselungs-Grenze. ViewModels bleiben unverändert.
- **`LocationService`** — auf dünnen Koordinator umgestellt, delegiert nur noch an den Controller.
- **Android** — `Foreground-Service` (`foregroundServiceType="location"`) mit `LocationManager` + `LocationListener`, hält die Aufnahme im Hintergrund am Leben.
- **iOS / MacCatalyst** — `CLLocationManager` mit `AllowBackgroundLocationUpdates` und `PausesLocationUpdatesAutomatically = false`.
- **Windows** — bisheriges Polling-Verhalten als Fallback beibehalten.
- **DI** — plattformabhängige Registrierung in `MauiProgram.cs`; iOS-Nutzungstexte ergänzt.

### Verifiziert
- Builds: Android ✓, Windows ✓, iOS ✓
- Deploy auf Android-Gerät getestet