### PR TITLE
Erfolge erst ab 2 Min. und 100 m: Qualifikationsregel für Trips

### DIFF
--- a/UniTracks.Maui.Views/Pages/Tabs/AchievementsPage.xaml
+++ b/UniTracks.Maui.Views/Pages/Tabs/AchievementsPage.xaml
@@ -87,6 +87,10 @@
 
                 <!-- Achievements -->
                 <Label Style="{StaticResource SectionHeader}" Text="ERFOLGE" />
+                <Label
+                    FontSize="11"
+                    Style="{StaticResource SubtitleLabel}"
+                    Text="Nur Trips ab 2 Minuten und 100 Metern zählen für Erfolge, XP und Streaks." />
             </VerticalStackLayout>
         </CollectionView.Header>
 

--- a/UniTracks.Models/Trip/TripQualification.cs
+++ b/UniTracks.Models/Trip/TripQualification.cs
@@ -1,0 +1,22 @@
+namespace UniTracks.Models.Trip;
+
+/// <summary>
+/// Decides whether a trip counts for gamification (achievements, XP, streaks, coins).
+/// Trips that are too short in time AND distance (e.g. accidentally started recordings
+/// or cheating attempts) are excluded so achievements cannot be unlocked with
+/// 10-second / 10-meter trips.
+/// </summary>
+public static class TripQualification
+{
+    /// <summary>Minimum duration a trip must last to count.</summary>
+    public static readonly TimeSpan MinDuration = TimeSpan.FromMinutes(2);
+
+    /// <summary>Minimum distance in meters a trip must cover to count.</summary>
+    public const double MinDistanceMeters = 100;
+
+    public static bool IsQualifying(Trip trip)
+    {
+        var duration = trip.EndTime - trip.StartTime;
+        return duration >= MinDuration && (trip.Distance ?? 0) >= MinDistanceMeters;
+    }
+}

--- a/UniTracks.Services/Game/CoinService.cs
+++ b/UniTracks.Services/Game/CoinService.cs
@@ -23,7 +23,9 @@ public class CoinService : ICoinService
 
     public async Task<ActivityStats> GetAsync()
     {
-        var trips = (await repository.GetAllAsync<Trip>(t => t.TripType!)).ToList();
+        var trips = (await repository.GetAllAsync<Trip>(t => t.TripType!))
+            .Where(TripQualification.IsQualifying)
+            .ToList();
         var stats = await gamificationService.ComputeAsync();
 
         return new ActivityStats

--- a/UniTracks.Services/Stats/GamificationService.cs
+++ b/UniTracks.Services/Stats/GamificationService.cs
@@ -21,7 +21,9 @@ public class GamificationService : IGamificationService
 
     public async Task<GamificationStats> ComputeAsync()
     {
-        var trips = (await repository.GetAllAsync<Trip>()).ToList();
+        var trips = (await repository.GetAllAsync<Trip>())
+            .Where(TripQualification.IsQualifying)
+            .ToList();
 
         double totalDistanceKm = trips.Sum(t => t.Distance ?? 0) / 1000.0;
         int totalTrips = trips.Count;


### PR DESCRIPTION
## Problem
Erfolge, XP, Streaks und Coins wurden aus **allen** Trips berechnet — auch aus 10-Sekunden/10-Meter-Aufzeichnungen. Damit ließen sich Erfolge wie „10 Trips“ praktisch ohne Aktivität erspielen.

## Lösung
Ein Trip zählt für Gamification nur noch, wenn er **mindestens 2 Minuten dauert UND mindestens 100 Meter lang ist** (Dauer aus `EndTime - StartTime`, da `TotalTime` nie befüllt wird). Kurze Hunderunden und Jogging zählen weiterhin normal; versehentliche Mini-Aufzeichnungen und Cheats nicht.

Bewusst **kein** Tageslimit: das würde legitime Tage (Joggen + mehrere Hunderunden) bestrafen.

## Änderungen
- **Neu:** `UniTracks.Models/Trip/TripQualification.cs` — zentrale Regel `IsQualifying(Trip)`
- `GamificationService`: filtert Trips vor Berechnung von Erfolgen, XP, Level und Streaks
- `CoinService`: filtert ebenfalls, damit die Coin-Ökonomie konsistent bleibt
- `AchievementsPage`: Hinweistext „Nur Trips ab 2 Minuten und 100 Metern zählen für Erfolge, XP und Streaks."

## Validierung
- `dotnet build` UniTracks.Services ✅
- `dotnet build` UniTracks.Maui.Views (inkl. XAML) ✅
- Deployment auf Android-Gerät getestet ✅