### PR TITLE
Release 0.1: Version anheben (signierte Android-APK)

### DIFF
--- a/UniTracks.Data/Migrations/20260906185956_AddTowerDefenseBestClear.Designer.cs
+++ b/UniTracks.Data/Migrations/20260906185956_AddTowerDefenseBestClear.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UniTracks.Data.SQLite;
 
@@ -10,14 +11,11 @@ using UniTracks.Data.SQLite;
 namespace UniTracks.Data.Migrations;
 
 [DbContext(typeof(SqliteDBContext))]
-partial class SqliteDBContextModelSnapshot : ModelSnapshot
+[Migration("20260906185956_AddTowerDefenseBestClear")]
+partial class _20260906185956_AddTowerDefenseBestClear
 {
-    // If you encounter a merge conflict in the line below, it means you need to
-    // discard one of the migration branches and recreate its migrations on top of
-    // the other branch. See https://aka.ms/efcore-docs-migrations-conflicts for more info.
-    public override string LastMigrationId => "20260906185956_AddTowerDefenseBestClear";
-
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder.HasAnnotation("ProductVersion", "11.0.0-preview.7.26381.103");

--- a/UniTracks.Data/Migrations/20260906185956_AddTowerDefenseBestClear.cs
+++ b/UniTracks.Data/Migrations/20260906185956_AddTowerDefenseBestClear.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UniTracks.Data.Migrations;
+
+/// <inheritdoc />
+public partial class _20260906185956_AddTowerDefenseBestClear : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "BestClearScore",
+            table: "DefenseRunProgresses",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.AddColumn<int>(
+            name: "BestClearWave",
+            table: "DefenseRunProgresses",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: 0);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "BestClearScore",
+            table: "DefenseRunProgresses");
+
+        migrationBuilder.DropColumn(
+            name: "BestClearWave",
+            table: "DefenseRunProgresses");
+    }
+}

--- a/UniTracks.Games/TowerDefense/DefenseEngine.cs
+++ b/UniTracks.Games/TowerDefense/DefenseEngine.cs
@@ -114,6 +114,8 @@ public static class DefenseEngine
             state.PendingSpawns.Enqueue(enemy);
         }
 
+        state.WaveSpawned = 0;
+        state.WaveLeaked = 0;
         state.SpawnCooldownMs = 0;
         state.Phase = DefensePhase.WaveRunning;
         return DefenseResult.Ok(0);
@@ -149,7 +151,19 @@ public static class DefenseEngine
 
         if (state.PendingSpawns.Count == 0 && state.Enemies.Count == 0)
         {
-            state.Energy += state.ClearBonus;
+            // Meritocratic energy: full clear-bonus only when nothing leaked, otherwise
+            // scaled by the share of the wave actually defeated.
+            int defeated = state.WaveSpawned - state.WaveLeaked;
+            double ratio = state.WaveSpawned == 0 ? 0 : (double)defeated / state.WaveSpawned;
+            state.Energy += (int)Math.Round(state.ClearBonus * ratio);
+
+            // A zero-leak clear is the only one that counts toward the record.
+            if (state.WaveLeaked == 0 && state.NextWave > state.BestClearWave)
+            {
+                state.BestClearWave = state.NextWave;
+                state.BestClearScore = state.Score;
+            }
+
             state.NextWave++;
             state.Phase = DefensePhase.Building;
         }
@@ -163,6 +177,7 @@ public static class DefenseEngine
         while (state.PendingSpawns.Count > 0 && state.SpawnCooldownMs <= 0)
         {
             var definition = state.PendingSpawns.Dequeue();
+            state.WaveSpawned++;
             int maxHp = (int)Math.Ceiling(definition.BaseHp * hpMultiplier);
             state.Enemies.Add(new ActiveEnemy
             {
@@ -187,6 +202,7 @@ public static class DefenseEngine
             if (enemy.Distance >= state.Map.TotalLength)
             {
                 state.Lives -= enemy.Definition.LeakDamage;
+                state.WaveLeaked++;
                 state.Enemies.RemoveAt(i);
                 state.Projectiles.RemoveAll(p => p.TargetEnemyId == enemy.Id);
             }

--- a/UniTracks.Games/TowerDefense/DefenseState.cs
+++ b/UniTracks.Games/TowerDefense/DefenseState.cs
@@ -32,6 +32,18 @@ public class DefenseState
     /// <summary>Number of the wave that will start next (1-based).</summary>
     public int NextWave { get; set; } = 1;
 
+    /// <summary>Highest wave number fully cleared with zero leaks (0 = none yet).</summary>
+    public int BestClearWave { get; set; }
+
+    /// <summary>The score at the moment the zero-leak best wave (<see cref="BestClearWave"/>) was cleared.</summary>
+    public int BestClearScore { get; set; }
+
+    /// <summary>Enemies spawned so far in the current wave.</summary>
+    public int WaveSpawned { get; set; }
+
+    /// <summary>Enemies that reached the end of the trail in the current wave.</summary>
+    public int WaveLeaked { get; set; }
+
     public DefensePhase Phase { get; set; } = DefensePhase.Building;
 
     /// <summary>Enemies of the running wave that still need to spawn.</summary>

--- a/UniTracks.Games/TowerDefense/EnemyCatalog.cs
+++ b/UniTracks.Games/TowerDefense/EnemyCatalog.cs
@@ -5,10 +5,10 @@ public static class EnemyCatalog
 {
     public static IReadOnlyList<EnemyDefinition> Enemies { get; } = new List<EnemyDefinition>
     {
-        new() { Id = "mosquito", Name = "Mücke", Icon = "🦟", BaseHp = 10, SpeedTilesPerSecond = 1.2, EnergyReward = 0, ScoreReward = 5 },
-        new() { Id = "gnat", Name = "Schnake", Icon = "🪰", BaseHp = 30, SpeedTilesPerSecond = 0.85, EnergyReward = 0, ScoreReward = 10 },
-        new() { Id = "wasp", Name = "Wespe", Icon = "🐝", BaseHp = 55, SpeedTilesPerSecond = 1.6, EnergyReward = 0, ScoreReward = 20 },
-        new() { Id = "hornet", Name = "Hornisse", Icon = "🪲", BaseHp = 220, SpeedTilesPerSecond = 0.65, EnergyReward = 0, ScoreReward = 60, LeakDamage = 3 },
+        new() { Id = "mosquito", Name = "Mücke", Icon = "🦟", BaseHp = 10, SpeedTilesPerSecond = 1.2, EnergyReward = 0, ScoreReward = 5, LeakDamage = 2 },
+        new() { Id = "gnat", Name = "Schnake", Icon = "🪰", BaseHp = 30, SpeedTilesPerSecond = 0.85, EnergyReward = 0, ScoreReward = 10, LeakDamage = 2 },
+        new() { Id = "wasp", Name = "Wespe", Icon = "🐝", BaseHp = 55, SpeedTilesPerSecond = 1.6, EnergyReward = 0, ScoreReward = 20, LeakDamage = 2 },
+        new() { Id = "hornet", Name = "Hornisse", Icon = "🪲", BaseHp = 220, SpeedTilesPerSecond = 0.65, EnergyReward = 0, ScoreReward = 60, LeakDamage = 6 },
     };
 
     public static EnemyDefinition? Find(string id) => Enemies.FirstOrDefault(e => e.Id == id);

--- a/UniTracks.Games/TowerDefense/EnemyDefinition.cs
+++ b/UniTracks.Games/TowerDefense/EnemyDefinition.cs
@@ -22,5 +22,5 @@ public record EnemyDefinition
     public int ScoreReward { get; init; }
 
     /// <summary>Lives lost when this enemy reaches the end of the trail.</summary>
-    public int LeakDamage { get; init; } = 1;
+    public int LeakDamage { get; init; } = 2;
 }

--- a/UniTracks.Games/TowerDefense/Persistence/DefenseRunProgress.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/DefenseRunProgress.cs
@@ -24,6 +24,12 @@ public record DefenseRunProgress
 
     public int Score { get; set; }
 
+    /// <summary>Highest wave fully cleared with zero leaks in this run (0 = none yet).</summary>
+    public int BestClearWave { get; set; }
+
+    /// <summary>The score at the moment the zero-leak best wave was cleared.</summary>
+    public int BestClearScore { get; set; }
+
     /// <summary>JSON-serialized list of <see cref="PlacedTower"/> of the current layout.</summary>
     public string TowersJson { get; set; } = "[]";
 

--- a/UniTracks.Maui/UniTracks.Maui.csproj
+++ b/UniTracks.Maui/UniTracks.Maui.csproj
@@ -17,7 +17,7 @@
 		<ApplicationId>com.agredoapplication.unitracks</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>0.1</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<DefaultLanguage>de-DE</DefaultLanguage>

--- a/UniTracks.Services/Game/TowerDefenseService.cs
+++ b/UniTracks.Services/Game/TowerDefenseService.cs
@@ -100,7 +100,10 @@ public class TowerDefenseService : ITowerDefenseService
             record = new DefenseRecord { ID = Guid.NewGuid() };
         }
 
-        if (clearedWave > record.BestWave || score > record.BestScore)
+        // Only a wave cleared with zero leaks counts toward the record. A leaky run can
+        // still reach a high wave, but it does not set a new best.
+        if (clearedWave > record.BestWave
+            || (clearedWave == record.BestWave && score > record.BestScore))
         {
             record.BestWave = Math.Max(record.BestWave, clearedWave);
             record.BestScore = Math.Max(record.BestScore, score);
@@ -131,6 +134,8 @@ public class TowerDefenseService : ITowerDefenseService
             ClearBonus = EnergyEconomy.ComputeClearBonus(stats),
             Lives = progress.Lives > 0 ? progress.Lives : map.StartLives,
             Score = progress.Score,
+            BestClearWave = progress.BestClearWave,
+            BestClearScore = progress.BestClearScore,
             NextWave = Math.Max(1, progress.Wave),
             Phase = DefensePhase.Building,
         };
@@ -152,6 +157,8 @@ public class TowerDefenseService : ITowerDefenseService
             MapId = state.Map.Id,
             Lives = state.Lives,
             Score = state.Score,
+            BestClearWave = state.BestClearWave,
+            BestClearScore = state.BestClearScore,
             TowersJson = SerializeTowers(state.Towers),
             UpdatedAt = DateTimeOffset.UtcNow,
         };

--- a/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
@@ -197,7 +197,7 @@ public partial class TowerDefensePageViewModel : ObservableObject
         if (State.Phase == DefensePhase.Lost && !runSaved)
         {
             runSaved = true;
-            ApplyProfile(await towerDefenseService.SaveRunResultAsync(State.ClearedWave, State.Score));
+            ApplyProfile(await towerDefenseService.SaveRunResultAsync(State.BestClearWave, State.BestClearScore));
 
             // Keep the failed layout + wave so the player can retry next time with fresh energy.
             await towerDefenseService.SaveRunAsync(State);

--- a/build-unitracks.bat
+++ b/build-unitracks.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set VERSION=1.0.0
+set VERSION=0.1
 set PROJECT=UniTracks.Maui\UniTracks.Maui.csproj
 set ANDROID_TFM=net11.0-android
 set WINDOWS_TFM=net11.0-windows10.0.26100.0


### PR DESCRIPTION
## Release 0.1
Erste signierte Android-Kandidaten-APK mit App-Version 0.1.

- `ApplicationDisplayVersion` → 0.1
- `build-unitracks.bat` → `VERSION=0.1`

### Signing
- Keystore `UniTracks.Maui\unitracks.keystore` (Alias `unitracks`) lokal erzeugt und per `.gitignore` ausgeschlossen — gleiches Muster wie Nexile/Finanzio.
- Release-Publish erzeugt `com.agredoapplication.unitracks-Signed.apk` (ca. 50 MB, CN=UniTracks).

Artefakt: `dist\UniTracks-0.1-android.apk` (git-ignored).