### PR TITLE
Android: Hintergrund-Standort, TabBar-Insets und Track-Glättung

### DIFF
--- a/UniTracks.Maui.Views/Controls/MapView.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/MapView.xaml.cs
@@ -43,7 +43,11 @@ public partial class MapView : ContentView
             return;
         }
 
-        var projected = locations
+        // Post-processing: draw the smoothed track (GPS jitter filtered/averaged). Raw points
+        // stay untouched in the database.
+        var smoothed = UniTracks.Services.Location.TrackSmoother.Smooth(locations);
+
+        var projected = smoothed
             .Select(location => SphericalMercator.FromLonLat(location.Longitude, location.Latitude))
             .ToArray();
 
@@ -51,7 +55,7 @@ public partial class MapView : ContentView
 
         if (projected.Length > 1)
         {
-            var speeds = ComputeSegmentSpeeds(locations);
+            var speeds = ComputeSegmentSpeeds(smoothed);
             var minSpeed = speeds.Min();
             var maxSpeed = speeds.Max();
 

--- a/UniTracks.Maui/Platforms/Android/AndroidManifest.xml
+++ b/UniTracks.Maui/Platforms/Android/AndroidManifest.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true">
-		<!-- Der ACW (Android Callable Wrapper) des Dienstes heisst crc64...BackgroundLocationService,
-		     nicht com.agredoapplication.unitracks... Nur so findet Android die registrierte Komponente. -->
-		<service android:name="crc64f55c63facadc3c93.BackgroundLocationService" android:exported="false" android:foregroundServiceType="location" />
+		<!-- Der BackgroundLocationService wird ueber das [Service]-Attribut in der Klasse deklariert,
+		     damit der ACW-Name immer stimmt. -->
 	</application>
 	<uses-permission android:name="android.permission.BATTERY_STATS" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-	<uses-feature android:name="android.permission.LOCATION.GPS" android:required="false" />
-	<uses-feature android:name="android.permission.LOCATION.NETWORK" android:required="false" />
+	<!-- ACCESS_BACKGROUND_LOCATION ist nicht noetig: Ein location-Foreground-Service, der im
+	     Vordergrund gestartet wird, darf auch im Hintergrund weiter aufzeichnen (While-in-Use). -->
+	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
+	<uses-feature android:name="android.hardware.location.network" android:required="false" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/UniTracks.Maui/Platforms/Android/BackgroundLocationService.cs
+++ b/UniTracks.Maui/Platforms/Android/BackgroundLocationService.cs
@@ -13,9 +13,10 @@ namespace UniTracks.Maui;
 
 /// <summary>
 /// Foreground service that keeps GPS recording alive while the app is in the background.
-/// Declared as a location foreground service in AndroidManifest.xml so the system keeps it
-/// running and does not throttle it in the background.
+/// The [Service] attribute generates the manifest entry (incl. location foregroundServiceType)
+/// with the correct Android Callable Wrapper name automatically.
 /// </summary>
+[Service(Exported = false, ForegroundServiceType = ForegroundService.TypeLocation)]
 public class BackgroundLocationService : Service
 {
     private const string ChannelId = "unitracks.location";
@@ -83,7 +84,14 @@ public class BackgroundLocationService : Service
             .SetOngoing(true)
             .Build();
 
-        StartForeground(NotificationId, notification);
+        if (Build.VERSION.SdkInt >= BuildVersionCodes.Q)
+        {
+            StartForeground(NotificationId, notification, ForegroundService.TypeLocation);
+        }
+        else
+        {
+            StartForeground(NotificationId, notification);
+        }
         isForeground = true;
     }
 
@@ -105,8 +113,15 @@ public class BackgroundLocationService : Service
             System.Diagnostics.Debug.WriteLine($"[UniTracks] GPS provider unavailable: {ex.Message}");
         }
 
-        locationManager.RequestLocationUpdates(
-            LocationManager.NetworkProvider, MinTimeMs, MinDistanceMeters, locationListener, Looper.MainLooper);
+        try
+        {
+            locationManager.RequestLocationUpdates(
+                LocationManager.NetworkProvider, MinTimeMs, MinDistanceMeters, locationListener, Looper.MainLooper);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UniTracks] Network provider unavailable: {ex.Message}");
+        }
 
         isUpdating = true;
     }

--- a/UniTracks.Maui/Platforms/Android/MainActivity.cs
+++ b/UniTracks.Maui/Platforms/Android/MainActivity.cs
@@ -1,6 +1,7 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using AndroidX.Core.View;
 
 namespace UniTracks.Maui
 {
@@ -11,9 +12,19 @@ namespace UniTracks.Maui
         {
             base.OnCreate(savedInstanceState);
 
-            // Systemleisten ans Dark-Theme anlehnen: Statusleiste = TabBar, Navigationsleiste = Seitenhintergrund
-            Window?.SetStatusBarColor(new Android.Graphics.Color(0x12, 0x1A, 0x14));   // SurfaceAlt
-            Window?.SetNavigationBarColor(new Android.Graphics.Color(0x0C, 0x12, 0x0E)); // Surface
+            // Edge-to-Edge deaktivieren: MAUI rendert auf aktuellem Android standardmaessig
+            // hinter die Systemleisten. Auf manchen Geraeten (z.B. Shiftphone 8, Android 15)
+            // liegt die Shell-TabBar dann hinter der Navigationsleiste bzw. rendert im
+            // Portrait leer/weiss (bekannter Insets-Bug). Mit DecorFitsSystemWindows(true)
+            // liegt der Inhalt garantiert zwischen Status- und Navigationsleiste.
+            if (Window is not null)
+            {
+                WindowCompat.SetDecorFitsSystemWindows(Window, true);
+
+                // Systemleisten ans Dark-Theme anlehnen: Statusleiste = TabBar, Navigationsleiste = Seitenhintergrund
+                Window.SetStatusBarColor(new Android.Graphics.Color(0x12, 0x1A, 0x14));   // SurfaceAlt
+                Window.SetNavigationBarColor(new Android.Graphics.Color(0x0C, 0x12, 0x0E)); // Surface
+            }
         }
     }
 }

--- a/UniTracks.Services/Data/GpsDataStorageService.cs
+++ b/UniTracks.Services/Data/GpsDataStorageService.cs
@@ -1,6 +1,7 @@
 using UniTracks.Data.Repository;
 using UniTracks.Models.GPS;
 using UniTracks.Models.Trip;
+using UniTracks.Services.Location;
 using LocationModel = UniTracks.Models.Location.Location;
 
 namespace UniTracks.Services.Data;
@@ -43,6 +44,15 @@ public class GpsDataStorageService : IGpsDataStorageService
         storeGate.Wait();
         try
         {
+            if (currentTrip is not null && currentTrip.Locations.Count > 2)
+            {
+                // Post-processing: replace the noisy incremental distance (accumulated from raw
+                // GPS points, which overestimates due to jitter) with the smoothed track distance.
+                // Raw points stay untouched in the database.
+                currentTrip.Distance = TrackSmoother.SmoothedDistanceMeters(currentTrip.Locations);
+                Repository.Update<Trip>(currentTrip).GetAwaiter().GetResult();
+            }
+
             currentTrip = null;
             ResetAggregates();
         }

--- a/UniTracks.Services/Location/TrackSmoother.cs
+++ b/UniTracks.Services/Location/TrackSmoother.cs
@@ -1,0 +1,159 @@
+using LocationModel = UniTracks.Models.Location.Location;
+
+namespace UniTracks.Services.Location;
+
+/// <summary>
+/// Post-processing smoothing for recorded GPS tracks. The raw points stay untouched in the
+/// database; this pipeline produces a cleaned view of a track for distance calculation and
+/// display. It removes GPS noise (jitter while standing, accuracy outliers, physically
+/// impossible jumps) and applies a light moving-average so the polyline follows the real path.
+/// </summary>
+public static class TrackSmoother
+{
+    /// <summary>Points with a worse (higher) accuracy than this are dropped.</summary>
+    public const double MaxAccuracyMeters = 25.0;
+
+    /// <summary>Points closer than this to the previous kept point are dropped (standing jitter).</summary>
+    public const double MinDistanceMeters = 4.0;
+
+    /// <summary>Jumps faster than this between consecutive points are treated as outliers.</summary>
+    public const double MaxSpeedMetersPerSecond = 30.0; // ~108 km/h, generous for sport tracks
+
+    /// <summary>Half-window of the moving average (2 => averages up to 5 points).</summary>
+    public const int SmoothingHalfWindow = 2;
+
+    /// <summary>
+    /// Returns a smoothed copy of <paramref name="track"/> (ordered by timestamp). The input
+    /// list is not modified. Speed/altitude of kept points are carried over from the nearest
+    /// original point; only the coordinates are smoothed.
+    /// </summary>
+    public static List<LocationModel> Smooth(IReadOnlyList<LocationModel> track)
+    {
+        if (track.Count < 3)
+        {
+            return track.ToList();
+        }
+
+        var ordered = track.OrderBy(l => l.Timestamp).ToList();
+
+        List<LocationModel> filtered = FilterNoise(ordered);
+
+        if (filtered.Count < 3)
+        {
+            return filtered;
+        }
+
+        return MovingAverage(filtered);
+    }
+
+    /// <summary>Distance in meters of the smoothed track.</summary>
+    public static double SmoothedDistanceMeters(IReadOnlyList<LocationModel> track)
+    {
+        var smoothed = Smooth(track);
+        double meters = 0;
+        for (var i = 1; i < smoothed.Count; i++)
+        {
+            meters += HaversineMeters(smoothed[i - 1], smoothed[i]);
+        }
+        return meters;
+    }
+
+    /// <summary>
+    /// Removes accuracy outliers, standing jitter and physically impossible jumps. Keeps the
+    /// first point as anchor and walks forward, only accepting plausible successors.
+    /// </summary>
+    private static List<LocationModel> FilterNoise(List<LocationModel> ordered)
+    {
+        var kept = new List<LocationModel>();
+
+        LocationModel? anchor = null;
+        foreach (var point in ordered)
+        {
+            // Drop points with unknown or bad accuracy — they are the main source of wild zick-zack.
+            if (point.Accuracy > 0 && point.Accuracy > MaxAccuracyMeters)
+            {
+                continue;
+            }
+
+            if (anchor is null)
+            {
+                kept.Add(point);
+                anchor = point;
+                continue;
+            }
+
+            double meters = HaversineMeters(anchor, point);
+            double seconds = (point.Timestamp - anchor.Timestamp).TotalSeconds;
+
+            // Standing jitter: ignore points that didn't move meaningfully.
+            if (meters < MinDistanceMeters)
+            {
+                continue;
+            }
+
+            // Outlier: a jump that would require impossible speed (teleport GPS fixes).
+            if (seconds > 0 && meters / seconds > MaxSpeedMetersPerSecond)
+            {
+                continue;
+            }
+
+            kept.Add(point);
+            anchor = point;
+        }
+
+        return kept;
+    }
+
+    /// <summary>
+    /// Light moving average over the coordinates (lat/lon/altitude). Timestamps, speed and
+    /// accuracy stay those of the center point so the track's timeline is preserved.
+    /// </summary>
+    private static List<LocationModel> MovingAverage(List<LocationModel> points)
+    {
+        var result = new List<LocationModel>(points.Count);
+
+        for (var i = 0; i < points.Count; i++)
+        {
+            int from = Math.Max(0, i - SmoothingHalfWindow);
+            int to = Math.Min(points.Count - 1, i + SmoothingHalfWindow);
+
+            double lat = 0, lon = 0, alt = 0;
+            for (var j = from; j <= to; j++)
+            {
+                lat += points[j].Latitude;
+                lon += points[j].Longitude;
+                alt += points[j].Altitude;
+            }
+            int count = to - from + 1;
+
+            var center = points[i];
+            result.Add(new LocationModel
+            {
+                ID = center.ID,
+                TripID = center.TripID,
+                Latitude = lat / count,
+                Longitude = lon / count,
+                Altitude = alt / count,
+                Accuracy = center.Accuracy,
+                Speed = center.Speed,
+                Heading = center.Heading,
+                HeadingAccuracy = center.HeadingAccuracy,
+                SpeedAccuracy = center.SpeedAccuracy,
+                Timestamp = center.Timestamp
+            });
+        }
+
+        return result;
+    }
+
+    private static double HaversineMeters(LocationModel a, LocationModel b)
+    {
+        const double earthRadiusMeters = 6371000;
+        double dLat = (b.Latitude - a.Latitude) * Math.PI / 180;
+        double dLon = (b.Longitude - a.Longitude) * Math.PI / 180;
+        double h = Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
+            + Math.Cos(a.Latitude * Math.PI / 180) * Math.Cos(b.Latitude * Math.PI / 180)
+            * Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        return earthRadiusMeters * 2 * Math.Atan2(Math.Sqrt(h), Math.Sqrt(1 - h));
+    }
+}

--- a/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
@@ -180,9 +180,17 @@ public partial class RecordTripTabPageViewModel : ObservableObject
 
             GpsDataStorageService.CurrentTripTypeId = SelectedTripType?.ID;
 
-            PermissionStatus locationAlwaysPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, Permission.LocationAlways);
+            PermissionStatus locationPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, Permission.LocationAlways);
 
-            if (locationAlwaysPermissionStatus is PermissionStatus.Granted)
+            // Ab Android 11 kann "Immer zulassen" nur noch in den Systemeinstellungen erteilt
+            // werden und ist hier nicht noetig: Der location-Foreground-Service wird im Vordergrund
+            // gestartet und darf damit auch im Hintergrund weiter aufzeichnen (While-in-Use reicht).
+            if (locationPermissionStatus is not PermissionStatus.Granted && OperatingSystem.IsAndroid())
+            {
+                locationPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, Permission.LocationWhenInUse);
+            }
+
+            if (locationPermissionStatus is PermissionStatus.Granted)
             {
                 await LocationService.StartListening();
             }


### PR DESCRIPTION
## Android-Plattform-Fixes

### Hintergrund-Standort
- `BackgroundLocationService` wird jetzt per `[Service]`-Attribut deklariert — der Android-Callable-Wrapper-Name stimmt damit automatisch (statt hartcodiert im Manifest)
- `StartForeground` ruft ab API 29 explizit mit `ForegroundService.TypeLocation` auf
- Network-Provider-Aufruf abgesichert (try/catch wie GPS) — eine `SecurityException` hätte den Service beim Start abstürzen lassen

### Permission-Flow
- **Fix für blockierten Aufnahme-Start**: Es wurde `LocationAlways` verlangt — ab Android 11 gibt es dafür keinen Runtime-Dialog mehr, Status war `Denied`, die Aufnahme startete nie
- Fallback auf `LocationWhenInUse`: reicht, weil ein aus dem Vordergrund gestarteter `location`-Foreground-Service auch im Hintergrund weiter aufzeichnen darf
- `ACCESS_BACKGROUND_LOCATION` entfernt (nicht nötig, spart Play-Store-Prüfung), korrekte `uses-feature`-Namen (`android.hardware.location.gps/network`)

### TabBar / Edge-to-Edge
- `WindowCompat.SetDecorFitsSystemWindows(Window, true)` in `MainActivity`: Auf manchen Geräten (z.B. Shiftphone 8, Android 15) lag die Shell-TabBar hinter der Navigationsleiste bzw. renderte im Portrait leer/weiß

### Track-Glättung (Post-Processing)
- Neuer `TrackSmoother`: Accuracy-Filter (>25 m), Ausreißer-Filter (>108 km/h-Sprünge), Mindestdistanz (4 m Stehen-Rauschen), Moving Average (5 Punkte)
- `trip.Distance` wird beim `FinalizeTrip()` geglättet nachberechnet — behebt zu lange Strecken durch GPS-Jitter
- `MapView` zeichnet die geglättete Linie
- **Rohpunkte bleiben unverändert in der DB** — keine Informationsverluste

Getestet auf Android 10 (Huawei P30 Pro) und Android 15 (Shiftphone 8).