### PR TITLE
Add About page with library list and GitHub links

### DIFF
--- a/UniTracks.Maui.Views/Pages/AboutPage.xaml
+++ b/UniTracks.Maui.Views/Pages/AboutPage.xaml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="UniTracks.Maui.Views.Pages.AboutPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewModels="clr-namespace:UniTracks.ViewModels.Pages;assembly=UniTracks.ViewModels"
+    Title="Über"
+    x:DataType="viewModels:AboutPageViewModel">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="20">
+
+            <!-- Hero -->
+            <Border
+                Background="{StaticResource HeroGradientBrush}"
+                Padding="24,20"
+                Stroke="{StaticResource CardStroke}"
+                StrokeThickness="1">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="24" />
+                </Border.StrokeShape>
+                <HorizontalStackLayout Spacing="16">
+                    <Border
+                        Background="{StaticResource AccentSoft}"
+                        HeightRequest="72"
+                        Stroke="{StaticResource AccentDim}"
+                        StrokeThickness="1"
+                        WidthRequest="72">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="36" />
+                        </Border.StrokeShape>
+                        <Label
+                            FontSize="34"
+                            HorizontalOptions="Center"
+                            Text="ℹ️"
+                            VerticalOptions="Center" />
+                    </Border>
+                    <VerticalStackLayout Spacing="2" VerticalOptions="Center">
+                        <Label Style="{StaticResource TitleLabel}" Text="{Binding AppName}" />
+                        <Label Style="{StaticResource SubtitleLabel}" Text="{Binding AppVersion, StringFormat='Version {0}'}" />
+                    </VerticalStackLayout>
+                </HorizontalStackLayout>
+            </Border>
+
+            <!-- Bremen with love -->
+            <Border Style="{StaticResource CardBorder}">
+                <HorizontalStackLayout Spacing="12">
+                    <Label FontSize="34" Text="❤️" VerticalOptions="Center" />
+                    <VerticalStackLayout Spacing="4" VerticalOptions="Center">
+                        <Label Style="{StaticResource TitleLabel}" FontSize="18" Text="Aus Bremen" />
+                        <Label Style="{StaticResource SubtitleLabel}" Text="{Binding BremenText}" />
+                    </VerticalStackLayout>
+                </HorizontalStackLayout>
+            </Border>
+
+            <!-- Agredo Application -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="ÜBER Agredo Application" />
+                <Border Style="{StaticResource CardBorder}">
+                    <VerticalStackLayout Spacing="10">
+                        <Label
+                            FontFamily="OpenSansSemibold"
+                            FontSize="16"
+                            Text="Agredo Application" />
+                        <Label Style="{StaticResource SubtitleLabel}" Text="{Binding AgredoText}" />
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+            <!-- Libraries -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="VERWENDETE BIBLIOTHEKEN" />
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Libraries}" Spacing="10">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:LibraryInfo">
+                            <Border Style="{StaticResource CardBorder}">
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnLibraryTapped" />
+                                </Border.GestureRecognizers>
+                                <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" RowSpacing="2">
+                                    <Label
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        FontFamily="OpenSansSemibold"
+                                        FontSize="15"
+                                        Text="{Binding Name}" />
+                                    <Label
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        FontSize="12"
+                                        Text="{Binding Version}"
+                                        TextColor="{StaticResource TextSecondary}" />
+                                    <HorizontalStackLayout
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Spacing="6"
+                                        VerticalOptions="Center">
+                                        <Border
+                                            Background="{StaticResource CardAlt}"
+                                            Padding="8,3"
+                                            Stroke="{StaticResource CardStroke}"
+                                            StrokeThickness="1">
+                                            <Border.StrokeShape>
+                                                <RoundRectangle CornerRadius="10" />
+                                            </Border.StrokeShape>
+                                            <Label
+                                                FontSize="10"
+                                                Style="{StaticResource StatLabel}"
+                                                Text="{Binding License}" />
+                                        </Border>
+                                        <Label
+                                            FontSize="16"
+                                            IsVisible="{Binding HasGitHubUrl}"
+                                            Text="↗"
+                                            TextColor="{StaticResource Accent}"
+                                            VerticalOptions="Center" />
+                                    </HorizontalStackLayout>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+            </VerticalStackLayout>
+
+            <Label
+                FontSize="11"
+                HorizontalTextAlignment="Center"
+                Style="{StaticResource SubtitleLabel}"
+                Text="Tippe auf eine Bibliothek, um deren GitHub-Seite zu öffnen." />
+
+            <Grid HeightRequest="20" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/UniTracks.Maui.Views/Pages/AboutPage.xaml.cs
+++ b/UniTracks.Maui.Views/Pages/AboutPage.xaml.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui.ApplicationModel;
+using UniTracks.ViewModels.Pages;
+
+namespace UniTracks.Maui.Views.Pages;
+
+public partial class AboutPage : ContentPage
+{
+	public AboutPage(AboutPageViewModel viewModel)
+	{
+		InitializeComponent();
+		BindingContext = viewModel;
+	}
+
+	private async void OnLibraryTapped(object? sender, TappedEventArgs e)
+	{
+		if (sender is BindableObject bindable
+			&& bindable.BindingContext is LibraryInfo library
+			&& !string.IsNullOrWhiteSpace(library.GitHubUrl))
+		{
+			await Launcher.Default.OpenAsync(new Uri(library.GitHubUrl));
+		}
+	}
+}

--- a/UniTracks.Maui.Views/Pages/Tabs/UserPage.xaml
+++ b/UniTracks.Maui.Views/Pages/Tabs/UserPage.xaml
@@ -62,5 +62,27 @@
                 </Grid>
             </Border>
         </VerticalStackLayout>
+
+        <!-- About section -->
+        <VerticalStackLayout Spacing="8">
+            <Label Style="{StaticResource SectionHeader}" Text="ÜBER" />
+            <Border Style="{StaticResource CardBorder}">
+                <Grid ColumnDefinitions="*,Auto">
+                    <VerticalStackLayout Grid.Column="0" Spacing="2" VerticalOptions="Center">
+                        <Label FontFamily="OpenSansSemibold" FontSize="15" Text="Über diese App" />
+                        <Label
+                            FontSize="12"
+                            Text="Agredo Application · Aus Bremen mit Liebe"
+                            TextColor="{StaticResource TextSecondary}" />
+                    </VerticalStackLayout>
+                    <Button
+                        Command="{Binding OpenAboutCommand}"
+                        Grid.Column="1"
+                        Style="{StaticResource SecondaryButton}"
+                        Text="Öffnen"
+                        VerticalOptions="Center" />
+                </Grid>
+            </Border>
+        </VerticalStackLayout>
     </VerticalStackLayout>
 </ContentPage>

--- a/UniTracks.Maui/App.xaml.cs
+++ b/UniTracks.Maui/App.xaml.cs
@@ -27,6 +27,7 @@ namespace UniTracks.Maui
             Routing.RegisterRoute(nameof(TripOverviewPage), typeof(TripOverviewPage));
             Routing.RegisterRoute(nameof(CityBuilderPage), typeof(CityBuilderPage));
             Routing.RegisterRoute(nameof(TowerDefensePage), typeof(TowerDefensePage));
+            Routing.RegisterRoute(nameof(AboutPage), typeof(AboutPage));
         }
 
         /// <summary>

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -188,6 +188,7 @@ public static class MauiProgram
         services.AddTransient<GameTabPage, GameTabPageViewModel>();
         services.AddTransient<CityBuilderPage, CityBuilderPageViewModel>();
         services.AddTransient<TowerDefensePage, TowerDefensePageViewModel>();
+        services.AddTransient<AboutPage, AboutPageViewModel>();
     }
 
     private static void RegisterPopups(IServiceCollection services)

--- a/UniTracks.ViewModels/Pages/AboutPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/AboutPageViewModel.cs
@@ -1,0 +1,145 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace UniTracks.ViewModels.Pages;
+
+public partial class AboutPageViewModel : ObservableObject
+{
+    public string AppName { get; } = "UniTracks";
+    public string AppVersion { get; } = "0.1";
+
+    /// <summary>
+    /// Kurze Erklärung, was Agredo Application ist.
+    /// </summary>
+    public string AgredoText { get; } =
+        "Agredo Application ist das Entwicklerstudio hinter UniTracks. " +
+        "Mit Fokus auf Datenschutz und Privatsphäre bauen wir Apps, die alle Daten " +
+        "lokal auf deinem Gerät halten – ohne Cloud, ohne Tracking, ohne versteckte Analyse.";
+
+    /// <summary>
+    /// Bremen mit Liebe.
+    /// </summary>
+    public string BremenText { get; } =
+        "UniTracks wurde in Bremen entwickelt – mit viel Liebe. ❤️";
+
+    public ObservableCollection<LibraryInfo> Libraries { get; }
+
+    public AboutPageViewModel()
+    {
+        Libraries = new ObservableCollection<LibraryInfo>(BuildLibraries());
+    }
+
+    private static IEnumerable<LibraryInfo> BuildLibraries()
+    {
+        yield return new LibraryInfo
+        {
+            Name = ".NET MAUI (Microsoft.Maui.Controls)",
+            Version = "11.0.0-preview.7.26406.9",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/maui",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "CommunityToolkit.Maui",
+            Version = "15.0.1",
+            License = "MIT",
+            GitHubUrl = "https://github.com/CommunityToolkit/Maui",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "CommunityToolkit.Mvvm",
+            Version = "8.4.2",
+            License = "MIT",
+            GitHubUrl = "https://github.com/CommunityToolkit/dotnet",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "Mapsui.Maui",
+            Version = "5.1.0",
+            License = "MIT",
+            GitHubUrl = "https://github.com/Mapsui/Mapsui",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "SkiaSharp.Views.Maui.Controls",
+            Version = "3.119.2",
+            License = "MIT",
+            GitHubUrl = "https://github.com/mono/SkiaSharp",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "LiteDB",
+            Version = "6.0.0-prerelease.81",
+            License = "MIT",
+            GitHubUrl = "https://github.com/litedb-org/LiteDB",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "Microsoft.EntityFrameworkCore.Sqlite",
+            Version = "11.0.0-preview.7.26381.103",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/efcore",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "Microsoft.EntityFrameworkCore.Design",
+            Version = "11.0.0-preview.7.26381.103",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/efcore",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "Microsoft.EntityFrameworkCore.Tools",
+            Version = "11.0.0-preview.7.26381.103",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/efcore",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "SQLitePCLRaw.bundle_e_sqlite3",
+            Version = "2.1.13",
+            License = "Apache-2.0",
+            GitHubUrl = "https://github.com/ericsink/SQLitePCL.raw",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "Microsoft.Extensions.Logging.Debug",
+            Version = "11.0.0-preview.7.26381.103",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/runtime",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "GeoCoordinate.NetStandard1",
+            Version = "1.0.1",
+            License = "MS-PL",
+            GitHubUrl = "https://github.com/AeonLucid/GeoCoordinate.NetStandard1",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "System.Net.Http",
+            Version = "4.3.4",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/runtime",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "System.Text.RegularExpressions",
+            Version = "4.3.1",
+            License = "MIT",
+            GitHubUrl = "https://github.com/dotnet/runtime",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "AgredoApplication.MVVM.Services",
+            Version = "1.2.0",
+            License = "Proprietär (Agredo Application)",
+        };
+        yield return new LibraryInfo
+        {
+            Name = "AgredoApplication.MVVM.Services.Maui",
+            Version = "1.2.0",
+            License = "Proprietär (Agredo Application)",
+        };
+    }
+}

--- a/UniTracks.ViewModels/Pages/LibraryInfo.cs
+++ b/UniTracks.ViewModels/Pages/LibraryInfo.cs
@@ -1,0 +1,16 @@
+namespace UniTracks.ViewModels.Pages;
+
+/// <summary>
+/// Eine verwendete Bibliothek mit Name, Version, Lizenz und optionalem Link zum
+/// GitHub-Repository. Wird im "Über"-Bereich angezeigt und beim Antippen im Browser geöffnet.
+/// </summary>
+public class LibraryInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public string License { get; set; } = string.Empty;
+    public string? GitHubUrl { get; set; }
+
+    /// <summary>Ob ein GitHub-Link vorhanden und damit antippbar ist.</summary>
+    public bool HasGitHubUrl => !string.IsNullOrWhiteSpace(GitHubUrl);
+}

--- a/UniTracks.ViewModels/Pages/Tabs/UserPagevViewModel.cs
+++ b/UniTracks.ViewModels/Pages/Tabs/UserPagevViewModel.cs
@@ -1,4 +1,5 @@
 using AgredoApplication.MVVM.Services.Abstractions.IO;
+using AgredoApplication.MVVM.Services.Abstractions.Navigation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UniTracks.Data.Repository;
@@ -11,13 +12,21 @@ public partial class UserPagevViewModel : ObservableObject
 {
     public IFileSystem FileSystem { get; }
     public IRepository Repository { get; }
+    public INavigationService Navigation { get; }
     public string DatabasePath { get; }
 
-    public UserPagevViewModel(IFileSystem fileSystem, IRepository repository)
+    public UserPagevViewModel(IFileSystem fileSystem, IRepository repository, INavigationService navigation)
     {
         FileSystem = fileSystem;
         Repository = repository;
+        Navigation = navigation;
         DatabasePath = repository.DatabasePath;
+    }
+
+    [RelayCommand]
+    private async Task OpenAbout()
+    {
+        await Navigation.ShellNavigationTo("AboutPage", new Dictionary<string, object>());
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Zusammenfassung

Fügt eine neue „Über"-Seite hinzu, die die Agredo Application erklärt, darauf hinweist, dass die App aus Bremen mit Liebe kommt, und alle verwendeten Bibliotheken (Name, Version, Lizenz) mit Tap-to-Open-GitHub-Links auflistet.

## Änderungen

- **Neue Dateien:**
  - `UniTracks.ViewModels/Pages/LibraryInfo.cs` – Modell mit Name, Version, Lizenz und `GitHubUrl` + `HasGitHubUrl`
  - `UniTracks.ViewModels/Pages/AboutPageViewModel.cs` – ViewModel mit App-Texten und 16 Bibliothekseinträgen
  - `UniTracks.Maui.Views/Pages/AboutPage.xaml` / `.xaml.cs` – UI mit `Launcher` zum Öffnen der GitHub-Links
- **Geänderte Dateien:**
  - `UniTracks.Maui/App.xaml.cs` – Route `AboutPage` registriert
  - `UniTracks.Maui/MauiProgram.cs` – DI-Registrierung von `AboutPage` / `AboutPageViewModel`
  - `UniTracks.ViewModels/Pages/Tabs/UserPagevViewModel.cs` – `OpenAbout`-Kommando
  - `UniTracks.Maui.Views/Pages/Tabs/UserPage.xaml` – „ÜBER"-Einstiegskarte

## Verifiziert

- `UniTracks.Maui` (Windows-Head) baut mit **0 Fehlern** (nur vorbestehende Warnungen)
- App läuft unter Windows