### PR TITLE
Tower-Defense: Energie kaufbar, Tower verteuert

### DIFF
--- a/UniTracks.Data/Migrations/20260907203231_AddEnergyPurchasesAndRunEnergy.Designer.cs
+++ b/UniTracks.Data/Migrations/20260907203231_AddEnergyPurchasesAndRunEnergy.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UniTracks.Data.SQLite;
 
@@ -10,14 +11,11 @@ using UniTracks.Data.SQLite;
 namespace UniTracks.Data.Migrations;
 
 [DbContext(typeof(SqliteDBContext))]
-partial class SqliteDBContextModelSnapshot : ModelSnapshot
+[Migration("20260907203231_AddEnergyPurchasesAndRunEnergy")]
+partial class _20260907203231_AddEnergyPurchasesAndRunEnergy
 {
-    // If you encounter a merge conflict in the line below, it means you need to
-    // discard one of the migration branches and recreate its migrations on top of
-    // the other branch. See https://aka.ms/efcore-docs-migrations-conflicts for more info.
-    public override string LastMigrationId => "20260907203231_AddEnergyPurchasesAndRunEnergy";
-
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder.HasAnnotation("ProductVersion", "11.0.0-preview.7.26381.103");

--- a/UniTracks.Data/Migrations/20260907203231_AddEnergyPurchasesAndRunEnergy.cs
+++ b/UniTracks.Data/Migrations/20260907203231_AddEnergyPurchasesAndRunEnergy.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UniTracks.Data.Migrations;
+
+/// <inheritdoc />
+public partial class _20260907203231_AddEnergyPurchasesAndRunEnergy : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "Energy",
+            table: "DefenseRunProgresses",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.CreateTable(
+            name: "EnergyPurchases",
+            columns: table => new
+            {
+                ID = table.Column<Guid>(type: "TEXT", nullable: false),
+                Energy = table.Column<int>(type: "INTEGER", nullable: false),
+                Coins = table.Column<int>(type: "INTEGER", nullable: false),
+                PurchasedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_EnergyPurchases", x => x.ID);
+            });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "EnergyPurchases");
+
+        migrationBuilder.DropColumn(
+            name: "Energy",
+            table: "DefenseRunProgresses");
+    }
+}

--- a/UniTracks.Data/SQLite/SqliteDBContext.cs
+++ b/UniTracks.Data/SQLite/SqliteDBContext.cs
@@ -26,6 +26,7 @@ public class SqliteDBContext : DbContext
     public DbSet<PlacedBuilding> PlacedBuildings { get; set; }
     public DbSet<CityExpansion> CityExpansions { get; set; }
     public DbSet<TowerUnlock> TowerUnlocks { get; set; }
+    public DbSet<EnergyPurchase> EnergyPurchases { get; set; }
     public DbSet<DefenseRecord> DefenseRecords { get; set; }
     public DbSet<DefenseRunProgress> DefenseRunProgresses { get; set; }
 

--- a/UniTracks.Games/Shared/Economy/EnergyEconomy.cs
+++ b/UniTracks.Games/Shared/Economy/EnergyEconomy.cs
@@ -5,15 +5,25 @@ namespace UniTracks.Games.Shared.Economy;
 /// <summary>
 /// In-run energy rules for the tower-defense game. Energy is the placement currency that
 /// lets a player build towers during a run. Unlike the coin balance, energy is not earned
-/// by playing — killing enemies grants nothing and clearing a wave only trickles a small,
-/// sport-based amount back. The budget therefore grows with the player's real activity
-/// (level-ups from XP, achievements, lifetime kilometers) rather than with in-game kills,
-/// so progress is tied to running and exercising, not to grinding a wave.
+/// by killing enemies — clearing a wave only trickles a small, sport-based amount back.
+/// The budget therefore grows with the player's real activity (level-ups from XP,
+/// achievements, lifetime kilometers) rather than with in-game kills, so progress is tied
+/// to running and exercising, not to grinding a wave. A player may additionally top the
+/// budget up with coins (a durable spend that is part of the computed coin balance).
 /// </summary>
 public static class EnergyEconomy
 {
     /// <summary>Enough to place a couple of starter towers and clear the first wave or two.</summary>
     public const int StartingEnergy = 60;
+
+    /// <summary>Coins paid for each point of energy bought with coin during a run.</summary>
+    public const int CoinsPerEnergy = 2;
+
+    /// <summary>Energy granted by a single coin-funded purchase (the buy button in the HUD).</summary>
+    public const int EnergyPackSize = 25;
+
+    /// <summary>Coins a coin-funded energy purchase of <paramref name="energy"/> points costs.</summary>
+    public static int CoinCostForEnergy(int energy) => energy * CoinsPerEnergy;
 
     /// <summary>Floor of energy trickled back after each cleared wave, so a brand-new player is never hard-stuck.</summary>
     public const int BaseClearBonus = 20;

--- a/UniTracks.Games/TowerDefense/DefenseEngine.cs
+++ b/UniTracks.Games/TowerDefense/DefenseEngine.cs
@@ -35,6 +35,13 @@ public static class DefenseEngine
     public static int ComputeUnlockSpent(IEnumerable<TowerUnlock> unlocks) =>
         unlocks.Sum(u => TowerCatalog.Find(u.TowerId)?.UnlockCost ?? 0);
 
+    /// <summary>Coins permanently spent on coin-funded energy top-ups (feeds the shared coin balance).</summary>
+    public static int ComputeEnergySpent(IEnumerable<EnergyPurchase> purchases) =>
+        purchases.Sum(p => p.Coins);
+
+    /// <summary>Grants energy to the running budget — used for coin-funded top-ups.</summary>
+    public static void GrantEnergy(DefenseState state, int energy) => state.Energy += energy;
+
     /// <summary>Validates a tower placement. Does not mutate anything.</summary>
     public static DefenseResult ValidatePlacement(DefenseState state, string towerId, int x, int y)
     {

--- a/UniTracks.Games/TowerDefense/DefenseState.cs
+++ b/UniTracks.Games/TowerDefense/DefenseState.cs
@@ -19,7 +19,7 @@ public class DefenseState
     /// <summary>The map this run is played on (drives the trail geometry and difficulty modifiers).</summary>
     public DefenseMap Map { get; init; } = MapCatalog.Default;
 
-    /// <summary>In-run placement currency, topped up by the sport-based wave clear bonus.</summary>
+    /// <summary>In-run placement currency, topped up by the sport-based wave clear bonus and coin-funded top-ups.</summary>
     public int Energy { get; set; }
 
     /// <summary>Sport-based energy returned after each cleared wave (see <see cref="Shared.Economy.EnergyEconomy"/>).</summary>

--- a/UniTracks.Games/TowerDefense/Persistence/DefenseRunProgress.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/DefenseRunProgress.cs
@@ -4,10 +4,9 @@ namespace UniTracks.Games.TowerDefense.Persistence;
 
 /// <summary>
 /// Persisted snapshot of the player's in-progress defense run. On reload the tower
-/// layout and current wave are restored, while energy is freshly recomputed from the
-/// player's activity (see <c>UniTracks.Games.Shared.Economy.EnergyEconomy</c>) so that
-/// progress always requires sport. A single row keeps the run as one unit and works the
-/// same on EF Core (SQLite) and LiteDB (iOS).
+/// layout, current wave and the energy budget (including any coin-funded top-ups) are
+/// restored, so a resumed run continues exactly where it was left. A single row keeps
+/// the run as one unit and works the same on EF Core (SQLite) and LiteDB (iOS).
 /// </summary>
 public record DefenseRunProgress
 {
@@ -19,6 +18,9 @@ public record DefenseRunProgress
 
     /// <summary>Id of the map the run is played on (see <c>MapCatalog</c>). Defaults to the easiest map.</summary>
     public string MapId { get; set; } = MapCatalog.Default.Id;
+
+    /// <summary>Current in-run energy budget, persisted so purchased energy survives a resume.</summary>
+    public int Energy { get; set; }
 
     public int Lives { get; set; }
 

--- a/UniTracks.Games/TowerDefense/Persistence/EnergyPurchase.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/EnergyPurchase.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UniTracks.Games.TowerDefense.Persistence;
+
+/// <summary>
+/// A coin-funded energy purchase made during a run. Energy itself is a per-run budget,
+/// but the coins spent are durable — recorded here so the always-computed coin balance
+/// (earned from activity minus all spending) stays in sync. Works on EF Core (SQLite)
+/// as well as LiteDB on iOS.
+/// </summary>
+public record EnergyPurchase
+{
+    [Key]
+    public Guid ID { get; init; }
+
+    /// <summary>Energy points granted to the run.</summary>
+    public int Energy { get; init; }
+
+    /// <summary>Coins paid for this purchase.</summary>
+    public int Coins { get; init; }
+
+    public DateTimeOffset PurchasedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/UniTracks.Games/TowerDefense/Persistence/ITowerDefenseStore.cs
+++ b/UniTracks.Games/TowerDefense/Persistence/ITowerDefenseStore.cs
@@ -10,6 +10,12 @@ public interface ITowerDefenseStore
 
     Task SaveUnlockAsync(TowerUnlock unlock);
 
+    /// <summary>Loads all coin-funded energy purchases (feeds the computed coin balance).</summary>
+    Task<IReadOnlyList<EnergyPurchase>> LoadEnergyPurchasesAsync();
+
+    /// <summary>Persists a coin-funded energy purchase.</summary>
+    Task SaveEnergyPurchaseAsync(EnergyPurchase purchase);
+
     Task<DefenseRecord?> LoadRecordAsync();
 
     Task SaveRecordAsync(DefenseRecord record);

--- a/UniTracks.Games/TowerDefense/TowerCatalog.cs
+++ b/UniTracks.Games/TowerDefense/TowerCatalog.cs
@@ -5,11 +5,11 @@ public static class TowerCatalog
 {
     public static IReadOnlyList<TowerDefinition> Towers { get; } = new List<TowerDefinition>
     {
-        new() { Id = "spray", Name = "Mückenspray", Description = "Schnelle Sprühstöße auf kurze Distanz.", Icon = "🧴", UnlockCost = 0, EnergyCost = 25, RangeTiles = 2.0, Damage = 4, FireIntervalMs = 550, ColorHex = "#4FC3F7", AttackStyle = AttackStyle.Spray },
-        new() { Id = "candle", Name = "Duftkerze", Description = "Räuchert gleichmäßig alles in der Nähe aus.", Icon = "🕯️", UnlockCost = 100, RequiredLevel = 2, EnergyCost = 45, RangeTiles = 2.5, Damage = 8, FireIntervalMs = 900, ColorHex = "#FFB74D", AttackStyle = AttackStyle.Cloud },
-        new() { Id = "zapper", Name = "Elektro-Falle", Description = "Langsam, aber vernichtend.", Icon = "⚡", UnlockCost = 250, RequiredLevel = 3, EnergyCost = 80, RangeTiles = 2.0, Damage = 22, FireIntervalMs = 1600, ColorHex = "#FFF176", AttackStyle = AttackStyle.Zap },
-        new() { Id = "frog", Name = "Frosch", Description = "Schnappt weit entfernte Mücken aus der Luft.", Icon = "🐸", UnlockCost = 400, RequiredLevel = 4, EnergyCost = 120, RangeTiles = 3.5, Damage = 14, FireIntervalMs = 1100, ColorHex = "#81C784", AttackStyle = AttackStyle.Tongue },
-        new() { Id = "gecko", Name = "Gecko", Description = "Der Endgegner für jeden Mückenschwarm.", Icon = "🦎", UnlockCost = 700, RequiredLevel = 5, RequiredAchievementId = "hundred-km", EnergyCost = 200, RangeTiles = 3.0, Damage = 38, FireIntervalMs = 1500, ColorHex = "#BA68C8", AttackStyle = AttackStyle.Tongue },
+        new() { Id = "spray", Name = "Mückenspray", Description = "Schnelle Sprühstöße auf kurze Distanz.", Icon = "🧴", UnlockCost = 0, EnergyCost = 30, RangeTiles = 2.0, Damage = 4, FireIntervalMs = 550, ColorHex = "#4FC3F7", AttackStyle = AttackStyle.Spray },
+        new() { Id = "candle", Name = "Duftkerze", Description = "Räuchert gleichmäßig alles in der Nähe aus.", Icon = "🕯️", UnlockCost = 150, RequiredLevel = 2, EnergyCost = 60, RangeTiles = 2.5, Damage = 8, FireIntervalMs = 900, ColorHex = "#FFB74D", AttackStyle = AttackStyle.Cloud },
+        new() { Id = "zapper", Name = "Elektro-Falle", Description = "Langsam, aber vernichtend.", Icon = "⚡", UnlockCost = 400, RequiredLevel = 3, EnergyCost = 110, RangeTiles = 2.0, Damage = 22, FireIntervalMs = 1600, ColorHex = "#FFF176", AttackStyle = AttackStyle.Zap },
+        new() { Id = "frog", Name = "Frosch", Description = "Schnappt weit entfernte Mücken aus der Luft.", Icon = "🐸", UnlockCost = 650, RequiredLevel = 4, EnergyCost = 160, RangeTiles = 3.5, Damage = 14, FireIntervalMs = 1100, ColorHex = "#81C784", AttackStyle = AttackStyle.Tongue },
+        new() { Id = "gecko", Name = "Gecko", Description = "Der Endgegner für jeden Mückenschwarm.", Icon = "🦎", UnlockCost = 1000, RequiredLevel = 5, RequiredAchievementId = "hundred-km", EnergyCost = 260, RangeTiles = 3.0, Damage = 38, FireIntervalMs = 1500, ColorHex = "#BA68C8", AttackStyle = AttackStyle.Tongue },
     };
 
     public static TowerDefinition? Find(string id) => Towers.FirstOrDefault(t => t.Id == id);

--- a/UniTracks.Games/TowerDefense/TowerDefinition.cs
+++ b/UniTracks.Games/TowerDefense/TowerDefinition.cs
@@ -2,7 +2,8 @@ namespace UniTracks.Games.TowerDefense;
 
 /// <summary>
 /// Static definition of a tower type. Towers are unlocked permanently with coins
-/// (financed by real activity) and placed during a run with energy earned from kills.
+/// (financed by real activity) and placed during a run with energy — topped up by the
+/// sport-based wave-clear bonus or bought with coins at the start of each run.
 /// </summary>
 public record TowerDefinition
 {

--- a/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml
+++ b/UniTracks.Maui.Views/Pages/TowerDefensePage.xaml
@@ -12,45 +12,57 @@
 
     <Grid RowDefinitions="Auto,*,Auto">
 
-        <!-- Top bar: coins + energy + lives + wave + sell toggle -->
-        <Grid Grid.Row="0" Padding="12,10" ColumnDefinitions="Auto,Auto,Auto,*,Auto" ColumnSpacing="8">
-            <Border Padding="12,8" Style="{StaticResource CardBorder}">
-                <HorizontalStackLayout Spacing="6">
-                    <Label FontSize="16" Text="🪙" VerticalOptions="Center" />
-                    <Label Style="{StaticResource TitleLabel}" Text="{Binding Profile.Coins, StringFormat='{0:N0}'}" VerticalOptions="Center" />
-                </HorizontalStackLayout>
-            </Border>
-            <Border Grid.Column="1" Padding="12,8" Style="{StaticResource CardBorder}">
-                <HorizontalStackLayout Spacing="6">
-                    <Label FontSize="16" Text="⚡" VerticalOptions="Center" />
-                    <Label Style="{StaticResource TitleLabel}" Text="{Binding EnergyLabel}" VerticalOptions="Center" />
-                </HorizontalStackLayout>
-            </Border>
-            <Border Grid.Column="2" Padding="12,8" Style="{StaticResource CardBorder}">
-                <HorizontalStackLayout Spacing="6">
-                    <Label FontSize="16" Text="❤️" VerticalOptions="Center" />
-                    <Label Style="{StaticResource TitleLabel}" Text="{Binding LivesLabel}" VerticalOptions="Center" />
-                </HorizontalStackLayout>
-            </Border>
-            <Border Grid.Column="3" Padding="12,8" Style="{StaticResource CardBorder}">
-                <VerticalStackLayout Spacing="0">
-                    <Label Style="{StaticResource TitleLabel}" Text="{Binding WaveLabel}" />
-                    <Label FontSize="10" Style="{StaticResource SubtitleLabel}" Text="{Binding BestLabel}" />
-                </VerticalStackLayout>
-            </Border>
-            <Border Grid.Column="4" Padding="12,8" Style="{StaticResource CardBorder}">
-                <Border.GestureRecognizers>
-                    <TapGestureRecognizer Command="{Binding ToggleSellModeCommand}" />
-                </Border.GestureRecognizers>
-                <Label FontSize="18" Text="💥" VerticalOptions="Center" HorizontalOptions="Center" />
-                <Border.Triggers>
-                    <DataTrigger Binding="{Binding IsSellMode}" TargetType="Border" Value="True">
-                        <Setter Property="BackgroundColor" Value="{StaticResource AccentSoft}" />
-                        <Setter Property="Stroke" Value="{StaticResource Accent}" />
-                    </DataTrigger>
-                </Border.Triggers>
-            </Border>
-        </Grid>
+        <!-- Top bar: coins + energy + buy-energy + lives + wave + sell toggle. Horizontally
+             scrollable so every stat stays reachable on narrow screens. -->
+        <ScrollView Grid.Row="0" HorizontalScrollBarVisibility="Never" Orientation="Horizontal">
+            <HorizontalStackLayout Padding="12,10" Spacing="8">
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <HorizontalStackLayout Spacing="6">
+                        <Label FontSize="16" Text="🪙" VerticalOptions="Center" />
+                        <Label Style="{StaticResource TitleLabel}" Text="{Binding Profile.Coins, StringFormat='{0:N0}'}" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                </Border>
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <HorizontalStackLayout Spacing="6">
+                        <Label FontSize="16" Text="⚡" VerticalOptions="Center" />
+                        <Label Style="{StaticResource TitleLabel}" Text="{Binding EnergyLabel}" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                </Border>
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding BuyEnergyCommand}" CommandParameter="{Binding EnergyPackSize}" />
+                    </Border.GestureRecognizers>
+                    <VerticalStackLayout Spacing="0" HorizontalOptions="Center">
+                        <Label FontSize="15" HorizontalTextAlignment="Center" Style="{StaticResource TitleLabel}" Text="{Binding EnergyPackSize, StringFormat='+{0} ⚡'}" />
+                        <Label FontSize="10" HorizontalTextAlignment="Center" Style="{StaticResource SubtitleLabel}" Text="{Binding EnergyPackCost, StringFormat='{0} 🪙'}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <HorizontalStackLayout Spacing="6">
+                        <Label FontSize="16" Text="❤️" VerticalOptions="Center" />
+                        <Label Style="{StaticResource TitleLabel}" Text="{Binding LivesLabel}" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                </Border>
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <VerticalStackLayout Spacing="0">
+                        <Label Style="{StaticResource TitleLabel}" Text="{Binding WaveLabel}" />
+                        <Label FontSize="10" Style="{StaticResource SubtitleLabel}" Text="{Binding BestLabel}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Padding="12,8" Style="{StaticResource CardBorder}">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding ToggleSellModeCommand}" />
+                    </Border.GestureRecognizers>
+                    <Label FontSize="18" Text="💥" VerticalOptions="Center" HorizontalOptions="Center" />
+                    <Border.Triggers>
+                        <DataTrigger Binding="{Binding IsSellMode}" TargetType="Border" Value="True">
+                            <Setter Property="BackgroundColor" Value="{StaticResource AccentSoft}" />
+                            <Setter Property="Stroke" Value="{StaticResource Accent}" />
+                        </DataTrigger>
+                    </Border.Triggers>
+                </Border>
+            </HorizontalStackLayout>
+        </ScrollView>
 
         <!-- Defense map with game-over overlay -->
         <Grid Grid.Row="1">

--- a/UniTracks.Services/Game/GameCatalogService.cs
+++ b/UniTracks.Services/Game/GameCatalogService.cs
@@ -36,10 +36,12 @@ public class GameCatalogService : IGameCatalogService
         var placed = await cityStore.LoadAsync();
         var expansions = await cityStore.LoadExpansionsAsync();
         var unlocks = await towerDefenseStore.LoadUnlocksAsync();
+        var energyPurchases = await towerDefenseStore.LoadEnergyPurchasesAsync();
         int earned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements);
         int spent = CityEngine.ComputeSpent(placed)
             + CityEngine.ComputeExpansionSpent(expansions)
-            + DefenseEngine.ComputeUnlockSpent(unlocks);
+            + DefenseEngine.ComputeUnlockSpent(unlocks)
+            + DefenseEngine.ComputeEnergySpent(energyPurchases);
         return Math.Max(0, earned - spent);
     }
 }

--- a/UniTracks.Services/Game/ITowerDefenseService.cs
+++ b/UniTracks.Services/Game/ITowerDefenseService.cs
@@ -15,6 +15,13 @@ public interface ITowerDefenseService
     /// <summary>Unlocks a tower permanently if it is known, new and affordable with coins.</summary>
     Task<UnlockResult> TryUnlockAsync(string towerId);
 
+    /// <summary>
+    /// Spends coins to top the current run's energy budget up by <paramref name="energy"/>
+    /// points. The spend is durable (fed into the computed coin balance) and the granted
+    /// energy is persisted with the run.
+    /// </summary>
+    Task<UnlockResult> BuyEnergyAsync(DefenseState state, int energy);
+
     /// <summary>Persists a finished run when it beats the stored best wave or score.</summary>
     Task<DefenseProfile> SaveRunResultAsync(int clearedWave, int score);
 

--- a/UniTracks.Services/Game/TowerDefenseService.cs
+++ b/UniTracks.Services/Game/TowerDefenseService.cs
@@ -82,6 +82,36 @@ public class TowerDefenseService : ITowerDefenseService
         return UnlockResult.Ok();
     }
 
+    public async Task<UnlockResult> BuyEnergyAsync(DefenseState state, int energy)
+    {
+        if (energy <= 0)
+        {
+            return UnlockResult.Fail("Ungültige Energiemenge.");
+        }
+
+        int cost = EnergyEconomy.CoinCostForEnergy(energy);
+        int coins = await gameCatalogService.GetCoinBalanceAsync();
+        if (coins < cost)
+        {
+            return UnlockResult.Fail($"Nicht genug Münzen — {energy} ⚡ kosten {cost:N0} 🪙, du hast {coins:N0}.");
+        }
+
+        // Persist the durable coin spend first so the computed balance reflects it, then
+        // grant the energy to the live run and keep the run's energy up-to-date.
+        await store.SaveEnergyPurchaseAsync(new EnergyPurchase
+        {
+            ID = Guid.NewGuid(),
+            Energy = energy,
+            Coins = cost,
+            PurchasedAt = DateTimeOffset.UtcNow,
+        });
+
+        DefenseEngine.GrantEnergy(state, energy);
+        await SaveRunAsync(state);
+
+        return UnlockResult.Ok();
+    }
+
     /// <summary>Human-readable achievement name for gate messages.</summary>
     private static string AchievementName(string id) => id switch
     {
@@ -130,7 +160,9 @@ public class TowerDefenseService : ITowerDefenseService
         {
             UnlockedTowerIds = unlocks.Select(u => u.TowerId).ToList(),
             Map = map,
-            Energy = EnergyEconomy.ComputeStartingEnergy(stats),
+            // Restore the energy the run was left with (including coin-funded top-ups).
+            // Falls back to the starting credit so pre-existing saved runs stay playable.
+            Energy = progress.Energy > 0 ? progress.Energy : EnergyEconomy.ComputeStartingEnergy(stats),
             ClearBonus = EnergyEconomy.ComputeClearBonus(stats),
             Lives = progress.Lives > 0 ? progress.Lives : map.StartLives,
             Score = progress.Score,
@@ -155,6 +187,7 @@ public class TowerDefenseService : ITowerDefenseService
             ID = Guid.NewGuid(),
             Wave = state.NextWave,
             MapId = state.Map.Id,
+            Energy = state.Energy,
             Lives = state.Lives,
             Score = state.Score,
             BestClearWave = state.BestClearWave,

--- a/UniTracks.Services/Game/TowerDefenseStore.cs
+++ b/UniTracks.Services/Game/TowerDefenseStore.cs
@@ -21,10 +21,28 @@ public class TowerDefenseStore : ITowerDefenseStore
 
     public Task SaveUnlockAsync(TowerUnlock unlock) => repository.Add(unlock);
 
+    public async Task<IReadOnlyList<EnergyPurchase>> LoadEnergyPurchasesAsync() =>
+        (await repository.GetAllAsync<EnergyPurchase>()).ToList();
+
+    public Task SaveEnergyPurchaseAsync(EnergyPurchase purchase) => repository.Add(purchase);
+
     public async Task<DefenseRecord?> LoadRecordAsync() =>
         (await repository.GetAllAsync<DefenseRecord>()).FirstOrDefault();
 
-    public Task SaveRecordAsync(DefenseRecord record) => repository.Update(record);
+    public async Task SaveRecordAsync(DefenseRecord record)
+    {
+        var existing = (await repository.GetAllAsync<DefenseRecord>()).FirstOrDefault();
+        if (existing is null)
+        {
+            await repository.Add(record);
+            return;
+        }
+
+        existing.BestWave = record.BestWave;
+        existing.BestScore = record.BestScore;
+        existing.UpdatedAt = record.UpdatedAt;
+        await repository.Update(existing);
+    }
 
     public async Task<DefenseRunProgress?> LoadRunAsync() =>
         (await repository.GetAllAsync<DefenseRunProgress>()).FirstOrDefault();
@@ -42,6 +60,7 @@ public class TowerDefenseStore : ITowerDefenseStore
         // throws an InvalidOperationException (IdentityConflict) when two instances share
         // the same key, which surfaced as the 0xc000027b stowed exception on placement.
         existing.Wave = run.Wave;
+        existing.Energy = run.Energy;
         existing.Lives = run.Lives;
         existing.Score = run.Score;
         existing.TowersJson = run.TowersJson;

--- a/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TowerDefensePageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using AgredoApplication.MVVM.Services.Abstractions.UI;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using UniTracks.Games.Shared.Economy;
 using UniTracks.Games.TowerDefense;
 using UniTracks.Services.Game;
 
@@ -139,6 +140,32 @@ public partial class TowerDefensePageViewModel : ObservableObject
     private void ToggleSellMode()
     {
         IsSellMode = !IsSellMode;
+    }
+
+    /// <summary>Energy granted by a single coin-funded purchase (the buy button in the HUD).</summary>
+    public int EnergyPackSize => EnergyEconomy.EnergyPackSize;
+
+    /// <summary>Coins a coin-funded energy pack costs.</summary>
+    public int EnergyPackCost => EnergyEconomy.CoinCostForEnergy(EnergyPackSize);
+
+    [RelayCommand]
+    private async Task BuyEnergy(int packSize)
+    {
+        if (IsChoosingMap || IsLost)
+        {
+            return;
+        }
+
+        int energy = packSize > 0 ? packSize : EnergyPackSize;
+        var result = await towerDefenseService.BuyEnergyAsync(State, energy);
+        if (!result.Success)
+        {
+            await dialogService.AlertAsync("Energie kaufen", result.ErrorMessage, "OK");
+            return;
+        }
+
+        RefreshLabels();
+        ApplyProfile(await towerDefenseService.GetProfileAsync());
     }
 
     [RelayCommand]
@@ -302,8 +329,8 @@ public partial class TowerDefensePageViewModel : ObservableObject
         ApplyProfile(profile);
 
         // Always show the map-selection overlay on entry so the player picks a trail. If a
-        // persisted run exists (towers + wave + map), offer it as a "resume" option; energy
-        // is freshly recomputed from activity when the player resumes.
+        // persisted run exists (towers + wave + map + energy, including any coin-funded
+        // top-ups), offer it as a "resume" option so the run continues where it was left.
         var savedRun = await towerDefenseService.LoadRunAsync();
         resumeRun = savedRun;
         CanResume = savedRun is not null;


### PR DESCRIPTION
## Tower-Defense: Energie kaufbar, Tower verteuert, Energie als Pro-Runde-Budget

- Energie ist jetzt ein Pro-Runde-Budget; Energie kann jederzeit mit Coins gekauft werden (25 Energie = 50 Coins) und boostet den laufenden Lauf.
- Neue persistente EnergyPurchase-Tabelle sowie Energy-Spalte in DefenseRunProgresses (Migration AddEnergyPurchasesAndRunEnergy).
- Tower-Preise in beiden Währungen erhöht.
- Obere Leiste horizontal scrollbar, inkl. neuer „+25 Energie"-Kaufkarte.
- SaveRecordAsync fügt fehlende DefenseRecord-Einträge ein, statt per Update zu crashen (fixes DbUpdateConcurrencyException beim ersten Game-Over).

Build: Alle Projekte (inkl. Windows-Target) fehlerfrei.