### PR TITLE
Statistik-Seite mit Strava-Metriken, Charts und Version 0.3

### DIFF
--- a/UniTracks.Maui.Views/Controls/Charts/BarChartView.cs
+++ b/UniTracks.Maui.Views/Controls/Charts/BarChartView.cs
@@ -1,0 +1,126 @@
+using System.Collections;
+using UniTracks.Models.Stats;
+
+namespace UniTracks.Maui.Views.Controls.Charts;
+
+/// <summary>
+/// Reusable bar chart (e.g. weekly kilometres). Pure GraphicsView + IDrawable,
+/// themed via bindable colors so it fits the app palette without new dependencies.
+/// Bind <see cref="ItemsSource"/> to a collection of <see cref="ChartEntry"/>.
+/// </summary>
+public class BarChartView : GraphicsView
+{
+    public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
+        nameof(ItemsSource), typeof(IEnumerable), typeof(BarChartView), null,
+        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+
+    public static readonly BindableProperty BarColorProperty = BindableProperty.Create(
+        nameof(BarColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#2E7D54"),
+        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+
+    public static readonly BindableProperty HighlightColorProperty = BindableProperty.Create(
+        nameof(HighlightColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#4DE790"),
+        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+
+    public static readonly BindableProperty LabelColorProperty = BindableProperty.Create(
+        nameof(LabelColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#6B7A6D"),
+        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+
+    public static readonly BindableProperty ValueColorProperty = BindableProperty.Create(
+        nameof(ValueColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#A9B8AC"),
+        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+
+    public BarChartView()
+    {
+        Drawable = new BarChartDrawable(this);
+    }
+
+    public IEnumerable? ItemsSource
+    {
+        get => (IEnumerable?)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    public Color BarColor
+    {
+        get => (Color)GetValue(BarColorProperty);
+        set => SetValue(BarColorProperty, value);
+    }
+
+    public Color HighlightColor
+    {
+        get => (Color)GetValue(HighlightColorProperty);
+        set => SetValue(HighlightColorProperty, value);
+    }
+
+    public Color LabelColor
+    {
+        get => (Color)GetValue(LabelColorProperty);
+        set => SetValue(LabelColorProperty, value);
+    }
+
+    public Color ValueColor
+    {
+        get => (Color)GetValue(ValueColorProperty);
+        set => SetValue(ValueColorProperty, value);
+    }
+
+    private sealed class BarChartDrawable : IDrawable
+    {
+        private const float LabelHeight = 18f;
+        private const float ValueHeight = 16f;
+        private const float MinBarHeight = 2f;
+
+        private readonly BarChartView owner;
+
+        public BarChartDrawable(BarChartView owner)
+        {
+            this.owner = owner;
+        }
+
+        public void Draw(ICanvas canvas, RectF dirtyRect)
+        {
+            var entries = owner.ItemsSource?.Cast<ChartEntry>().ToList();
+            if (entries is null || entries.Count == 0)
+            {
+                return;
+            }
+
+            float chartBottom = dirtyRect.Height - LabelHeight;
+            float chartTop = ValueHeight;
+            float chartHeight = Math.Max(1f, chartBottom - chartTop);
+
+            double maxValue = Math.Max(entries.Max(e => e.Value), 0.001);
+
+            float slotWidth = dirtyRect.Width / entries.Count;
+            float barWidth = Math.Min(slotWidth * 0.6f, 42f);
+            float cornerRadius = Math.Min(6f, barWidth / 3f);
+
+            canvas.FontSize = 10f;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                float center = slotWidth * i + slotWidth / 2f;
+
+                float barHeight = Math.Max(MinBarHeight, (float)(entry.Value / maxValue) * chartHeight);
+                var barRect = new RectF(center - barWidth / 2f, chartBottom - barHeight, barWidth, barHeight);
+
+                canvas.FillColor = entry.IsHighlighted ? owner.HighlightColor : owner.BarColor;
+                canvas.FillRoundedRectangle(barRect, cornerRadius, cornerRadius, 0, 0);
+
+                if (entry.Value > 0)
+                {
+                    canvas.FontColor = owner.ValueColor;
+                    string valueText = entry.Value >= 10 ? entry.Value.ToString("0") : entry.Value.ToString("0.#");
+                    canvas.DrawString(valueText, center - slotWidth / 2f, 0, slotWidth, ValueHeight,
+                        HorizontalAlignment.Center, VerticalAlignment.Center);
+                }
+
+                canvas.FontColor = owner.LabelColor;
+                canvas.DrawString(entry.Label, center - slotWidth / 2f, chartBottom, slotWidth, LabelHeight,
+                    HorizontalAlignment.Center, VerticalAlignment.Center);
+            }
+        }
+    }
+}

--- a/UniTracks.Maui.Views/Controls/Charts/LineChartView.cs
+++ b/UniTracks.Maui.Views/Controls/Charts/LineChartView.cs
@@ -1,0 +1,176 @@
+using System.Collections;
+
+namespace UniTracks.Maui.Views.Controls.Charts;
+
+/// <summary>
+/// Reusable line/area chart for one or two numeric series (e.g. speed and altitude
+/// profiles along a trip). Pure GraphicsView + IDrawable; each series is normalized
+/// to its own min/max so different units can share one plot. Series are smoothed
+/// with a small moving average before rendering.
+/// </summary>
+public class LineChartView : GraphicsView
+{
+    public static readonly BindableProperty PrimaryValuesProperty = BindableProperty.Create(
+        nameof(PrimaryValues), typeof(IList<double>), typeof(LineChartView), null,
+        propertyChanged: (b, _, _) => ((LineChartView)b).Invalidate());
+
+    public static readonly BindableProperty SecondaryValuesProperty = BindableProperty.Create(
+        nameof(SecondaryValues), typeof(IList<double>), typeof(LineChartView), null,
+        propertyChanged: (b, _, _) => ((LineChartView)b).Invalidate());
+
+    public static readonly BindableProperty LineColorProperty = BindableProperty.Create(
+        nameof(LineColor), typeof(Color), typeof(LineChartView), Color.FromArgb("#4DE790"),
+        propertyChanged: (b, _, _) => ((LineChartView)b).Invalidate());
+
+    public static readonly BindableProperty FillColorProperty = BindableProperty.Create(
+        nameof(FillColor), typeof(Color), typeof(LineChartView), Color.FromArgb("#334DE790"),
+        propertyChanged: (b, _, _) => ((LineChartView)b).Invalidate());
+
+    public static readonly BindableProperty SecondaryColorProperty = BindableProperty.Create(
+        nameof(SecondaryColor), typeof(Color), typeof(LineChartView), Color.FromArgb("#6B7A6D"),
+        propertyChanged: (b, _, _) => ((LineChartView)b).Invalidate());
+
+    public LineChartView()
+    {
+        Drawable = new LineChartDrawable(this);
+    }
+
+    public IList<double>? PrimaryValues
+    {
+        get => (IList<double>?)GetValue(PrimaryValuesProperty);
+        set => SetValue(PrimaryValuesProperty, value);
+    }
+
+    public IList<double>? SecondaryValues
+    {
+        get => (IList<double>?)GetValue(SecondaryValuesProperty);
+        set => SetValue(SecondaryValuesProperty, value);
+    }
+
+    public Color LineColor
+    {
+        get => (Color)GetValue(LineColorProperty);
+        set => SetValue(LineColorProperty, value);
+    }
+
+    public Color FillColor
+    {
+        get => (Color)GetValue(FillColorProperty);
+        set => SetValue(FillColorProperty, value);
+    }
+
+    public Color SecondaryColor
+    {
+        get => (Color)GetValue(SecondaryColorProperty);
+        set => SetValue(SecondaryColorProperty, value);
+    }
+
+    private sealed class LineChartDrawable : IDrawable
+    {
+        private const float Padding = 4f;
+        private const int SmoothingWindow = 5;
+
+        private readonly LineChartView owner;
+
+        public LineChartDrawable(LineChartView owner)
+        {
+            this.owner = owner;
+        }
+
+        public void Draw(ICanvas canvas, RectF dirtyRect)
+        {
+            float width = dirtyRect.Width - Padding * 2;
+            float height = dirtyRect.Height - Padding * 2;
+            if (width <= 0 || height <= 0)
+            {
+                return;
+            }
+
+            var secondary = Normalize(owner.SecondaryValues);
+            if (secondary is { Count: > 1 })
+            {
+                var secondaryPath = BuildPath(secondary, width, height);
+                canvas.StrokeColor = owner.SecondaryColor;
+                canvas.StrokeSize = 1.5f;
+                canvas.StrokeDashPattern = new[] { 4f, 3f };
+                canvas.DrawPath(secondaryPath);
+                canvas.StrokeDashPattern = null;
+            }
+
+            var primary = Normalize(owner.PrimaryValues);
+            if (primary is not { Count: > 1 })
+            {
+                return;
+            }
+
+            var linePath = BuildPath(primary, width, height);
+
+            var fillPath = BuildPath(primary, width, height);
+            fillPath.LineTo(Padding + width, Padding + height);
+            fillPath.LineTo(Padding, Padding + height);
+            fillPath.Close();
+
+            canvas.FillColor = owner.FillColor;
+            canvas.FillPath(fillPath);
+
+            canvas.StrokeColor = owner.LineColor;
+            canvas.StrokeSize = 2.5f;
+            canvas.DrawPath(linePath);
+        }
+
+        private static PathF BuildPath(IReadOnlyList<float> normalized, float width, float height)
+        {
+            var path = new PathF();
+            for (int i = 0; i < normalized.Count; i++)
+            {
+                float x = Padding + width * i / (normalized.Count - 1);
+                float y = Padding + height * (1f - normalized[i]);
+                if (i == 0)
+                {
+                    path.MoveTo(x, y);
+                }
+                else
+                {
+                    path.LineTo(x, y);
+                }
+            }
+
+            return path;
+        }
+
+        private static List<float>? Normalize(IEnumerable? values)
+        {
+            if (values is not IList<double> list || list.Count == 0)
+            {
+                return null;
+            }
+
+            var smoothed = Smooth(list);
+            double min = smoothed.Min();
+            double max = smoothed.Max();
+            double range = Math.Max(max - min, 0.0001);
+
+            return smoothed.Select(v => (float)((v - min) / range)).ToList();
+        }
+
+        private static List<double> Smooth(IList<double> values)
+        {
+            var result = new List<double>(values.Count);
+            int half = SmoothingWindow / 2;
+            for (int i = 0; i < values.Count; i++)
+            {
+                int from = Math.Max(0, i - half);
+                int to = Math.Min(values.Count - 1, i + half);
+                double sum = 0;
+                for (int j = from; j <= to; j++)
+                {
+                    sum += values[j];
+                }
+
+                result.Add(sum / (to - from + 1));
+            }
+
+            return result;
+        }
+    }
+}

--- a/UniTracks.Maui.Views/Controls/MapView.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/MapView.xaml.cs
@@ -44,8 +44,14 @@ public partial class MapView : ContentView
         }
 
         // Post-processing: draw the smoothed track (GPS jitter filtered/averaged). Raw points
-        // stay untouched in the database.
+        // stay untouched in the database. The smoother may drop every point (e.g. all fixes
+        // with bad accuracy) — then there is simply nothing to draw.
         var smoothed = UniTracks.Services.Location.TrackSmoother.Smooth(locations);
+
+        if (smoothed.Count == 0)
+        {
+            return;
+        }
 
         var projected = smoothed
             .Select(location => SphericalMercator.FromLonLat(location.Longitude, location.Latitude))

--- a/UniTracks.Maui.Views/Pages/StatisticsPage.xaml
+++ b/UniTracks.Maui.Views/Pages/StatisticsPage.xaml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="UniTracks.Maui.Views.Pages.StatisticsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:charts="clr-namespace:UniTracks.Maui.Views.Controls.Charts;assembly=UniTracks.Maui.Views"
+    xmlns:vm="clr-namespace:UniTracks.ViewModels.Pages;assembly=UniTracks.ViewModels"
+    Title="Statistik"
+    x:DataType="vm:StatisticsPageViewModel">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="20">
+
+            <!-- Week overview (Strava style: time, distance, elevation first) -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="DIESE WOCHE" />
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                    <Border Grid.Column="0" Style="{StaticResource AccentChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="ZEIT" />
+                            <Label Style="{StaticResource StatValue}" Text="{Binding WeekMovingTimeText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="DISTANZ" />
+                            <Label Style="{StaticResource StatValue}" Text="{Binding WeekDistanceText, StringFormat='{0} km'}" />
+                            <Label
+                                FontSize="11"
+                                Style="{StaticResource SubtitleLabel}"
+                                Text="{Binding WeekDeltaText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="HÖHENMETER" />
+                            <Label Style="{StaticResource StatValue}" Text="{Binding WeekElevationText, StringFormat='{0} m'}" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                    <Border Grid.Column="0" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding WeekTripsText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="TRIPS" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding WeekActiveDaysText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="AKTIVE TAGE" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <HorizontalStackLayout Spacing="6">
+                                <Label FontSize="20" Text="🔥" VerticalOptions="Center" />
+                                <Label Style="{StaticResource StatValue}" Text="{Binding StreakText}" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label Style="{StaticResource StatLabel}" Text="STREAK (TAGE)" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+            </VerticalStackLayout>
+
+            <!-- Averages -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="DURCHSCHNITT PRO TRIP" />
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                    <Border Grid.Column="0" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding AvgDistanceText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="DISTANZ" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding AvgMovingTimeText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="ZEIT" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding AvgPaceText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="PACE" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+            </VerticalStackLayout>
+
+            <!-- Year to date -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="DIESES JAHR" />
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                    <Border Grid.Column="0" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding YearDistanceText, StringFormat='{0} km'}" />
+                            <Label Style="{StaticResource StatLabel}" Text="KILOMETER" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatValue}" Text="{Binding YearTripsText}" />
+                            <Label Style="{StaticResource StatLabel}" Text="TRIPS" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+            </VerticalStackLayout>
+
+            <!-- Level -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="LEVEL" />
+                <Border Padding="20" Style="{StaticResource CardBorder}">
+                    <VerticalStackLayout Spacing="10">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Grid.Column="0" Style="{StaticResource TitleLabel}" Text="{Binding LevelLabel}" />
+                            <Label
+                                Grid.Column="1"
+                                Style="{StaticResource SubtitleLabel}"
+                                Text="{Binding XpLabel}"
+                                VerticalTextAlignment="Center" />
+                        </Grid>
+                        <ProgressBar
+                            HeightRequest="8"
+                            Progress="{Binding LevelProgressFraction}"
+                            ProgressColor="{StaticResource Accent}" />
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+            <!-- Weekly chart -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="KILOMETER PRO WOCHE" />
+                <Border Padding="16,16,16,10" Style="{StaticResource CardBorder}">
+                    <charts:BarChartView HeightRequest="170" ItemsSource="{Binding WeeklyChart}" />
+                </Border>
+            </VerticalStackLayout>
+
+            <!-- Records -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="REKORDE" />
+                <Border Style="{StaticResource CardBorder}">
+                    <VerticalStackLayout Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🥾" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Längster Trip" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding LongestTripText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="⚡" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Schnellster Ø-Speed" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding FastestSpeedText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🏃" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Schnellste Pace" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding FastestPaceText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="⏱️" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Längste Bewegungszeit" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding LongestMovingTimeText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="⛰️" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Maximale Höhe" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding MaxAltitudeText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🧗" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Meiste Höhenmeter (Trip)" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding MostElevationText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+            <!-- Games -->
+            <VerticalStackLayout Spacing="8">
+                <Label Style="{StaticResource SectionHeader}" Text="SPIELE" />
+                <Border Style="{StaticResource CardBorder}">
+                    <VerticalStackLayout Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🪙" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Münzen verdient (gesamt)" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding CoinsEarnedText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🏰" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Beste Tower-Defense-Welle" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding DefenseBestWaveText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <HorizontalStackLayout Grid.Column="0" Spacing="10">
+                                <Label FontSize="18" Text="🎯" VerticalOptions="Center" />
+                                <Label FontSize="15" Text="Bester Tower-Defense-Score" VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Column="1"
+                                FontFamily="OpenSansSemibold"
+                                FontSize="15"
+                                Text="{Binding DefenseBestScoreText}"
+                                TextColor="{StaticResource Accent}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/UniTracks.Maui.Views/Pages/StatisticsPage.xaml.cs
+++ b/UniTracks.Maui.Views/Pages/StatisticsPage.xaml.cs
@@ -1,0 +1,12 @@
+using UniTracks.ViewModels.Pages;
+
+namespace UniTracks.Maui.Views.Pages;
+
+public partial class StatisticsPage : ContentPage
+{
+    public StatisticsPage(StatisticsPageViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/UniTracks.Maui.Views/Pages/Tabs/UserPage.xaml
+++ b/UniTracks.Maui.Views/Pages/Tabs/UserPage.xaml
@@ -7,6 +7,7 @@
     Title="Profil"
     x:DataType="viewModels:UserPagevViewModel">
 
+    <ScrollView>
     <VerticalStackLayout Padding="20" Spacing="20">
 
         <!-- Profile hero -->
@@ -18,28 +19,95 @@
             <Border.StrokeShape>
                 <RoundRectangle CornerRadius="24" />
             </Border.StrokeShape>
-            <HorizontalStackLayout Spacing="16">
-                <Border
-                    Background="{StaticResource AccentSoft}"
-                    HeightRequest="72"
-                    Stroke="{StaticResource AccentDim}"
-                    StrokeThickness="1"
-                    WidthRequest="72">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="36" />
-                    </Border.StrokeShape>
-                    <Image
-                        Aspect="AspectFit"
-                        HeightRequest="36"
-                        Source="user.png"
-                        WidthRequest="36" />
-                </Border>
-                <VerticalStackLayout Spacing="2" VerticalOptions="Center">
-                    <Label Style="{StaticResource TitleLabel}" Text="Dein Profil" />
-                    <Label Style="{StaticResource SubtitleLabel}" Text="Bereit für den nächsten Trip" />
-                </VerticalStackLayout>
-            </HorizontalStackLayout>
+            <VerticalStackLayout Spacing="16">
+                <HorizontalStackLayout Spacing="16">
+                    <Border
+                        Background="{StaticResource AccentSoft}"
+                        HeightRequest="72"
+                        Stroke="{StaticResource AccentDim}"
+                        StrokeThickness="1"
+                        WidthRequest="72">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="36" />
+                        </Border.StrokeShape>
+                        <Image
+                            Aspect="AspectFit"
+                            HeightRequest="36"
+                            Source="user.png"
+                            WidthRequest="36" />
+                    </Border>
+                    <VerticalStackLayout Spacing="2" VerticalOptions="Center">
+                        <Label Style="{StaticResource TitleLabel}" Text="Dein Profil" />
+                        <Label Style="{StaticResource SubtitleLabel}" Text="Bereit für den nächsten Trip" />
+                    </VerticalStackLayout>
+                </HorizontalStackLayout>
+
+                <!-- Quick progress chips -->
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                    <Border Grid.Column="0" Style="{StaticResource AccentChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="LEVEL" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding LevelText}"
+                                TextColor="{StaticResource Accent}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="STREAK" />
+                            <HorizontalStackLayout Spacing="4">
+                                <Label FontSize="14" Text="🔥" VerticalOptions="Center" />
+                                <Label
+                                    FontFamily="OpenSansSemibold"
+                                    FontSize="16"
+                                    Text="{Binding StreakText}"
+                                    VerticalOptions="Center" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="GESAMT" />
+                            <HorizontalStackLayout Spacing="3">
+                                <Label
+                                    FontFamily="OpenSansSemibold"
+                                    FontSize="16"
+                                    Text="{Binding TotalDistanceText}" />
+                                <Label
+                                    FontSize="11"
+                                    Text="km"
+                                    TextColor="{StaticResource TextMuted}"
+                                    VerticalOptions="End" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+            </VerticalStackLayout>
         </Border>
+
+        <!-- Progress section -->
+        <VerticalStackLayout Spacing="8">
+            <Label Style="{StaticResource SectionHeader}" Text="FORTSCHRITT" />
+            <Border Style="{StaticResource CardBorder}">
+                <Grid ColumnDefinitions="*,Auto">
+                    <VerticalStackLayout Grid.Column="0" Spacing="2" VerticalOptions="Center">
+                        <Label FontFamily="OpenSansSemibold" FontSize="15" Text="Statistiken" />
+                        <Label
+                            FontSize="12"
+                            Text="Wochenübersicht, Rekorde und Spiele"
+                            TextColor="{StaticResource TextSecondary}" />
+                    </VerticalStackLayout>
+                    <Button
+                        Command="{Binding OpenStatisticsCommand}"
+                        Grid.Column="1"
+                        Style="{StaticResource SecondaryButton}"
+                        Text="Öffnen"
+                        VerticalOptions="Center" />
+                </Grid>
+            </Border>
+        </VerticalStackLayout>
 
         <!-- Data section -->
         <VerticalStackLayout Spacing="8">
@@ -107,4 +175,5 @@
             </Border>
         </VerticalStackLayout>
     </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
+++ b/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
@@ -3,6 +3,7 @@
     x:Class="UniTracks.Maui.Views.Pages.TripOverviewPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:charts="clr-namespace:UniTracks.Maui.Views.Controls.Charts;assembly=UniTracks.Maui.Views"
     xmlns:controls="clr-namespace:UniTracks.Maui.Views.Controls;assembly=UniTracks.Maui.Views"
     xmlns:models="clr-namespace:UniTracks.Models.Trip;assembly=UniTracks.Models"
     xmlns:vm="clr-namespace:UniTracks.ViewModels.Pages;assembly=UniTracks.ViewModels"
@@ -79,6 +80,81 @@
                         </VerticalStackLayout>
                     </Border>
                 </Grid>
+
+                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
+                    <Border Grid.Column="0" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="BEWEGUNG" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding MovingTimeText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="PAUSE" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding StoppedTimeText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="HÖHE" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="14"
+                                Text="{Binding AltitudeText}"
+                                VerticalOptions="Center" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="3" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="PACE /KM" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding PaceText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                </Grid>
+            </VerticalStackLayout>
+        </Border>
+
+        <!-- Speed / altitude profile -->
+        <Border
+            Margin="16"
+            Padding="14,10"
+            Style="{StaticResource CardBorder}"
+            IsVisible="{Binding HasProfile}"
+            VerticalOptions="End">
+            <VerticalStackLayout Spacing="6">
+                <HorizontalStackLayout Spacing="14">
+                    <HorizontalStackLayout Spacing="5">
+                        <BoxView
+                            BackgroundColor="{StaticResource Accent}"
+                            CornerRadius="2"
+                            HeightRequest="4"
+                            VerticalOptions="Center"
+                            WidthRequest="14" />
+                        <Label Style="{StaticResource StatLabel}" Text="KM/H" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <HorizontalStackLayout Spacing="5">
+                        <BoxView
+                            BackgroundColor="{StaticResource TextMuted}"
+                            CornerRadius="2"
+                            HeightRequest="4"
+                            VerticalOptions="Center"
+                            WidthRequest="14" />
+                        <Label Style="{StaticResource StatLabel}" Text="HÖHE" VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                </HorizontalStackLayout>
+                <charts:LineChartView
+                    HeightRequest="110"
+                    PrimaryValues="{Binding SpeedProfile}"
+                    SecondaryValues="{Binding AltitudeProfile}" />
             </VerticalStackLayout>
         </Border>
     </Grid>

--- a/UniTracks.Maui/App.xaml.cs
+++ b/UniTracks.Maui/App.xaml.cs
@@ -29,6 +29,7 @@ namespace UniTracks.Maui
             Routing.RegisterRoute(nameof(TowerDefensePage), typeof(TowerDefensePage));
             Routing.RegisterRoute(nameof(AboutPage), typeof(AboutPage));
             Routing.RegisterRoute(nameof(FeedbackPage), typeof(FeedbackPage));
+            Routing.RegisterRoute(nameof(StatisticsPage), typeof(StatisticsPage));
         }
 
         /// <summary>

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -143,6 +143,7 @@ public static class MauiProgram
         services.AddSingleton<ILocationService, LocationService>();
         services.AddSingleton<IGpsDataStorageService, GpsDataStorageService>();
         services.AddSingleton<IGamificationService, GamificationService>();
+        services.AddSingleton<IStatisticsService, StatisticsService>();
         services.AddSingleton<TripDistanceRecalculator>();
 
         // BugBear feedback (version is read automatically from the app's display version).
@@ -209,6 +210,7 @@ public static class MauiProgram
         services.AddTransient<AboutPage>();
         services.AddTransient<FeedbackPageViewModel>();
         services.AddTransient<FeedbackPage>();
+        services.AddTransient<StatisticsPage, StatisticsPageViewModel>();
     }
 
     private static void RegisterPopups(IServiceCollection services)

--- a/UniTracks.Maui/UniTracks.Maui.csproj
+++ b/UniTracks.Maui/UniTracks.Maui.csproj
@@ -17,8 +17,8 @@
 		<ApplicationId>com.agredoapplication.unitracks</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>0.2</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+		<ApplicationDisplayVersion>0.3</ApplicationDisplayVersion>
+		<ApplicationVersion>2</ApplicationVersion>
 
 		<DefaultLanguage>de-DE</DefaultLanguage>
 	</PropertyGroup>

--- a/UniTracks.Models/Stats/ChartEntry.cs
+++ b/UniTracks.Models/Stats/ChartEntry.cs
@@ -1,0 +1,16 @@
+namespace UniTracks.Models.Stats;
+
+/// <summary>
+/// One bar/point in a chart. Shared between ViewModels (which build the series)
+/// and the chart custom controls (which render it) so both stay MVVM-friendly.
+/// </summary>
+public record ChartEntry
+{
+    /// <summary>Short axis label, e.g. a week start date or category name.</summary>
+    public string Label { get; init; } = string.Empty;
+
+    public double Value { get; init; }
+
+    /// <summary>Render this entry accentuated (e.g. the current week).</summary>
+    public bool IsHighlighted { get; init; }
+}

--- a/UniTracks.Services/Stats/IStatisticsService.cs
+++ b/UniTracks.Services/Stats/IStatisticsService.cs
@@ -1,0 +1,79 @@
+namespace UniTracks.Services.Stats;
+
+/// <summary>Kilometres of one calendar week (Monday-start).</summary>
+public record WeeklyDistance
+{
+    public DateTime WeekStart { get; init; }
+
+    public double DistanceKm { get; init; }
+}
+
+/// <summary>
+/// Aggregated progress snapshot for the statistics page: current week vs. last week,
+/// all-time records, the last weeks as chart buckets and the game-side highlights.
+/// </summary>
+public record StatisticsSnapshot
+{
+    public double WeekDistanceKm { get; init; }
+
+    public double LastWeekDistanceKm { get; init; }
+
+    public int WeekTrips { get; init; }
+
+    public int WeekActiveDays { get; init; }
+
+    /// <summary>Moving time across this week's trips (Strava-style headline metric).</summary>
+    public TimeSpan WeekMovingTime { get; init; }
+
+    /// <summary>Climbed metres across this week's trips.</summary>
+    public double WeekElevationGainM { get; init; }
+
+    public double TotalDistanceKm { get; init; }
+
+    public int TotalTrips { get; init; }
+
+    /// <summary>Distance covered in the current calendar year.</summary>
+    public double YearDistanceKm { get; init; }
+
+    public int YearTrips { get; init; }
+
+    public double AverageDistanceKm { get; init; }
+
+    /// <summary>Average moving time per trip (trips without GPS points fall back to trip duration).</summary>
+    public TimeSpan AverageMovingTime { get; init; }
+
+    /// <summary>Average pace in seconds per kilometre; null when no trip has usable data.</summary>
+    public double? AveragePaceSecondsPerKm { get; init; }
+
+    public double LongestTripKm { get; init; }
+
+    public double FastestAverageSpeedKmh { get; init; }
+
+    public double MaxAltitudeM { get; init; }
+
+    /// <summary>Best pace over a single trip (s/km); null without usable GPS data.</summary>
+    public double? FastestPaceSecondsPerKm { get; init; }
+
+    /// <summary>Most climbed metres within a single trip.</summary>
+    public double MostElevationGainM { get; init; }
+
+    /// <summary>Longest moving time of a single trip.</summary>
+    public TimeSpan LongestMovingTime { get; init; }
+
+    /// <summary>Weekly kilometres, oldest first, ending with the current week.</summary>
+    public IReadOnlyList<WeeklyDistance> RecentWeeks { get; init; } = Array.Empty<WeeklyDistance>();
+
+    /// <summary>Lifetime coins earned from activity (before any spending).</summary>
+    public int CoinsEarnedTotal { get; init; }
+
+    public int? DefenseBestWave { get; init; }
+
+    public int? DefenseBestScore { get; init; }
+}
+
+/// <summary>Computes aggregated progress statistics from trips and game state.</summary>
+public interface IStatisticsService
+{
+    /// <param name="weekCount">Number of weekly buckets (including the current week) to return.</param>
+    Task<StatisticsSnapshot> GetSnapshotAsync(int weekCount = 8);
+}

--- a/UniTracks.Services/Stats/StatisticsService.cs
+++ b/UniTracks.Services/Stats/StatisticsService.cs
@@ -1,0 +1,126 @@
+using UniTracks.Data.Repository;
+using UniTracks.Games.Shared.Economy;
+using UniTracks.Games.Shared.Persistence;
+using UniTracks.Games.TowerDefense.Persistence;
+using UniTracks.Models.Trip;
+
+namespace UniTracks.Services.Stats;
+
+/// <summary>
+/// Builds the <see cref="StatisticsSnapshot"/> from qualifying trips (same filter as
+/// achievements/coins) plus the game stores. All aggregation is computed on demand —
+/// nothing is persisted, so stats can never drift from the underlying data.
+/// </summary>
+public class StatisticsService : IStatisticsService
+{
+    private readonly IRepository repository;
+    private readonly IActivityStatsSource activityStats;
+    private readonly ITowerDefenseStore towerDefenseStore;
+
+    public StatisticsService(IRepository repository, IActivityStatsSource activityStats, ITowerDefenseStore towerDefenseStore)
+    {
+        this.repository = repository;
+        this.activityStats = activityStats;
+        this.towerDefenseStore = towerDefenseStore;
+    }
+
+    public async Task<StatisticsSnapshot> GetSnapshotAsync(int weekCount = 8)
+    {
+        // Locations are needed for moving time and elevation gain, so load them eagerly.
+        var trips = (await repository.GetAllAsync<Trip>(trip => trip.Locations))
+            .Where(TripQualification.IsQualifying)
+            .ToList();
+
+        // Per-trip derived metrics, keyed by trip id.
+        var metrics = trips.ToDictionary(
+            t => t.ID,
+            t =>
+            {
+                var ordered = t.Locations?.OrderBy(l => l.Timestamp).ToList();
+                if (ordered is null || ordered.Count < 2)
+                {
+                    return (Moving: t.EndTime - t.StartTime, ElevationGain: 0.0);
+                }
+
+                var (moving, _) = TripMetricsCalculator.ComputeMovingAndStopped(ordered);
+                return (Moving: moving > TimeSpan.Zero ? moving : t.EndTime - t.StartTime,
+                    ElevationGain: TripMetricsCalculator.ComputeElevationGain(ordered));
+            });
+
+        var currentWeekStart = StartOfWeek(DateTime.Today);
+        var lastWeekStart = currentWeekStart.AddDays(-7);
+        var oldestWeekStart = currentWeekStart.AddDays(-7 * (weekCount - 1));
+        var yearStart = new DateTime(DateTime.Today.Year, 1, 1);
+
+        var currentWeekTrips = trips
+            .Where(t => t.StartTime.LocalDateTime.Date >= currentWeekStart)
+            .ToList();
+        var lastWeekTrips = trips
+            .Where(t => t.StartTime.LocalDateTime.Date >= lastWeekStart && t.StartTime.LocalDateTime.Date < currentWeekStart)
+            .ToList();
+        var yearTrips = trips
+            .Where(t => t.StartTime.LocalDateTime.Date >= yearStart)
+            .ToList();
+
+        var weeks = new List<WeeklyDistance>(weekCount);
+        for (int i = 0; i < weekCount; i++)
+        {
+            var weekStart = oldestWeekStart.AddDays(7 * i);
+            var weekEnd = weekStart.AddDays(7);
+            double km = trips
+                .Where(t => t.StartTime.LocalDateTime.Date >= weekStart && t.StartTime.LocalDateTime.Date < weekEnd)
+                .Sum(t => t.Distance ?? 0) / 1000.0;
+            weeks.Add(new WeeklyDistance { WeekStart = weekStart, DistanceKm = km });
+        }
+
+        var stats = await activityStats.GetAsync();
+        int coinsEarned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements);
+
+        var record = await towerDefenseStore.LoadRecordAsync();
+
+        // Pace (s/km) per trip — only meaningful for trips with real distance and time.
+        var tripPaces = trips
+            .Select(t => (DistanceKm: (t.Distance ?? 0) / 1000.0, Moving: metrics[t.ID].Moving))
+            .Where(x => x.DistanceKm >= 0.1 && x.Moving.TotalSeconds > 0)
+            .Select(x => x.Moving.TotalSeconds / x.DistanceKm)
+            .ToList();
+
+        double totalMovingSeconds = metrics.Values.Sum(m => m.Moving.TotalSeconds);
+
+        return new StatisticsSnapshot
+        {
+            WeekDistanceKm = Math.Round(currentWeekTrips.Sum(t => t.Distance ?? 0) / 1000.0, 1),
+            LastWeekDistanceKm = Math.Round(lastWeekTrips.Sum(t => t.Distance ?? 0) / 1000.0, 1),
+            WeekTrips = currentWeekTrips.Count,
+            WeekActiveDays = currentWeekTrips.Select(t => t.StartTime.LocalDateTime.Date).Distinct().Count(),
+            WeekMovingTime = TimeSpan.FromSeconds(currentWeekTrips.Sum(t => metrics[t.ID].Moving.TotalSeconds)),
+            WeekElevationGainM = Math.Round(currentWeekTrips.Sum(t => metrics[t.ID].ElevationGain)),
+            TotalDistanceKm = Math.Round(trips.Sum(t => t.Distance ?? 0) / 1000.0, 1),
+            TotalTrips = trips.Count,
+            YearDistanceKm = Math.Round(yearTrips.Sum(t => t.Distance ?? 0) / 1000.0, 1),
+            YearTrips = yearTrips.Count,
+            AverageDistanceKm = Math.Round(trips.Select(t => t.Distance ?? 0).DefaultIfEmpty(0).Average() / 1000.0, 1),
+            AverageMovingTime = trips.Count > 0
+                ? TimeSpan.FromSeconds(totalMovingSeconds / trips.Count)
+                : TimeSpan.Zero,
+            AveragePaceSecondsPerKm = tripPaces.Count > 0 ? tripPaces.Average() : null,
+            LongestTripKm = Math.Round(trips.Select(t => t.Distance ?? 0).DefaultIfEmpty(0).Max() / 1000.0, 1),
+            FastestAverageSpeedKmh = Math.Round(trips.Select(t => t.AverageSpeed ?? 0).DefaultIfEmpty(0).Max() * 3.6, 1),
+            MaxAltitudeM = Math.Round(trips.Select(t => t.MaxAltitude ?? 0).DefaultIfEmpty(0).Max()),
+            FastestPaceSecondsPerKm = tripPaces.Count > 0 ? tripPaces.Min() : null,
+            MostElevationGainM = Math.Round(metrics.Values.Select(m => m.ElevationGain).DefaultIfEmpty(0).Max()),
+            LongestMovingTime = TimeSpan.FromSeconds(metrics.Values.Select(m => m.Moving.TotalSeconds).DefaultIfEmpty(0).Max()),
+            RecentWeeks = weeks,
+            CoinsEarnedTotal = coinsEarned,
+            DefenseBestWave = record?.BestWave,
+            DefenseBestScore = record?.BestScore,
+        };
+    }
+
+    /// <summary>Monday of the week containing <paramref name="date"/> (German convention).</summary>
+    private static DateTime StartOfWeek(DateTime date)
+    {
+        int daysSinceMonday = ((int)date.DayOfWeek + 6) % 7;
+        return date.Date.AddDays(-daysSinceMonday);
+    }
+}

--- a/UniTracks.Services/Stats/TripMetricsCalculator.cs
+++ b/UniTracks.Services/Stats/TripMetricsCalculator.cs
@@ -1,0 +1,61 @@
+namespace UniTracks.Services.Stats;
+
+/// <summary>
+/// Derives per-trip activity metrics (moving/stopped time, elevation gain) from the
+/// recorded GPS points. These are not stored on the trip, so every consumer (trip
+/// overview, statistics) shares this one implementation to stay consistent.
+/// </summary>
+public static class TripMetricsCalculator
+{
+    /// <summary>Speed at or above which a point counts as moving (m/s).</summary>
+    public const double MovingThresholdMs = 0.5;
+
+    /// <summary>Gaps between fixes longer than this count as neither moving nor stopped.</summary>
+    public static readonly TimeSpan MaxGap = TimeSpan.FromSeconds(30);
+
+    /// <summary>Positive altitude deltas smaller than this are treated as GPS noise (m).</summary>
+    private const double ElevationNoiseThresholdM = 0.5;
+
+    /// <param name="ordered">GPS points ordered by timestamp; needs at least two points.</param>
+    public static (TimeSpan Moving, TimeSpan Stopped) ComputeMovingAndStopped(IReadOnlyList<Models.Location.Location> ordered)
+    {
+        double movingSeconds = 0;
+        double stoppedSeconds = 0;
+
+        for (int i = 1; i < ordered.Count; i++)
+        {
+            var dt = ordered[i].Timestamp - ordered[i - 1].Timestamp;
+            if (dt <= TimeSpan.Zero || dt > MaxGap)
+            {
+                continue;
+            }
+
+            if (ordered[i].Speed >= MovingThresholdMs)
+            {
+                movingSeconds += dt.TotalSeconds;
+            }
+            else
+            {
+                stoppedSeconds += dt.TotalSeconds;
+            }
+        }
+
+        return (TimeSpan.FromSeconds(movingSeconds), TimeSpan.FromSeconds(stoppedSeconds));
+    }
+
+    /// <summary>Total climbed metres — the sum of positive altitude deltas above the noise floor.</summary>
+    public static double ComputeElevationGain(IReadOnlyList<Models.Location.Location> ordered)
+    {
+        double gain = 0;
+        for (int i = 1; i < ordered.Count; i++)
+        {
+            double delta = ordered[i].Altitude - ordered[i - 1].Altitude;
+            if (delta > ElevationNoiseThresholdM)
+            {
+                gain += delta;
+            }
+        }
+
+        return gain;
+    }
+}

--- a/UniTracks.ViewModels/Pages/StatisticsPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/StatisticsPageViewModel.cs
@@ -1,0 +1,172 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using UniTracks.Models.Stats;
+using UniTracks.Services.Stats;
+
+namespace UniTracks.ViewModels.Pages;
+
+/// <summary>
+/// Progress statistics at a glance: current week vs. last week, level, weekly chart,
+/// all-time records and the game highlights. Data comes from <see cref="IStatisticsService"/>
+/// (aggregation) and <see cref="IGamificationService"/> (level/streak).
+/// </summary>
+public partial class StatisticsPageViewModel : ObservableObject
+{
+    private static readonly CultureInfo GermanCulture = CultureInfo.GetCultureInfo("de-DE");
+
+    private readonly IStatisticsService statisticsService;
+    private readonly IGamificationService gamificationService;
+
+    public StatisticsPageViewModel(IStatisticsService statisticsService, IGamificationService gamificationService)
+    {
+        this.statisticsService = statisticsService;
+        this.gamificationService = gamificationService;
+        _ = LoadAsync();
+    }
+
+    [ObservableProperty]
+    private string weekDistanceText = "-";
+
+    [ObservableProperty]
+    private string weekDeltaText = string.Empty;
+
+    [ObservableProperty]
+    private string weekTripsText = "-";
+
+    [ObservableProperty]
+    private string weekActiveDaysText = "-";
+
+    [ObservableProperty]
+    private string streakText = "-";
+
+    [ObservableProperty]
+    private string weekMovingTimeText = "-";
+
+    [ObservableProperty]
+    private string weekElevationText = "-";
+
+    [ObservableProperty]
+    private string yearDistanceText = "-";
+
+    [ObservableProperty]
+    private string yearTripsText = "-";
+
+    [ObservableProperty]
+    private string avgDistanceText = "-";
+
+    [ObservableProperty]
+    private string avgMovingTimeText = "-";
+
+    [ObservableProperty]
+    private string avgPaceText = "-";
+
+    [ObservableProperty]
+    private string fastestPaceText = "-";
+
+    [ObservableProperty]
+    private string mostElevationText = "-";
+
+    [ObservableProperty]
+    private string longestMovingTimeText = "-";
+
+    [ObservableProperty]
+    private string levelLabel = "Level 1";
+
+    [ObservableProperty]
+    private string xpLabel = "0 XP";
+
+    [ObservableProperty]
+    private double levelProgressFraction;
+
+    [ObservableProperty]
+    private string longestTripText = "-";
+
+    [ObservableProperty]
+    private string fastestSpeedText = "-";
+
+    [ObservableProperty]
+    private string maxAltitudeText = "-";
+
+    [ObservableProperty]
+    private string coinsEarnedText = "-";
+
+    [ObservableProperty]
+    private string defenseBestWaveText = "-";
+
+    [ObservableProperty]
+    private string defenseBestScoreText = "-";
+
+    public ObservableCollection<ChartEntry> WeeklyChart { get; } = new();
+
+    private async Task LoadAsync()
+    {
+        var snapshot = await statisticsService.GetSnapshotAsync();
+        var gamification = await gamificationService.ComputeAsync();
+
+        WeekDistanceText = snapshot.WeekDistanceKm.ToString("0.0", GermanCulture);
+        WeekDeltaText = BuildDeltaText(snapshot.WeekDistanceKm - snapshot.LastWeekDistanceKm);
+        WeekTripsText = snapshot.WeekTrips.ToString(GermanCulture);
+        WeekActiveDaysText = snapshot.WeekActiveDays.ToString(GermanCulture);
+        StreakText = gamification.CurrentStreakDays.ToString(GermanCulture);
+        WeekMovingTimeText = FormatDuration(snapshot.WeekMovingTime);
+        WeekElevationText = snapshot.WeekElevationGainM.ToString("0", GermanCulture);
+
+        YearDistanceText = snapshot.YearDistanceKm.ToString("0.0", GermanCulture);
+        YearTripsText = snapshot.YearTrips.ToString(GermanCulture);
+
+        AvgDistanceText = $"{snapshot.AverageDistanceKm.ToString("0.0", GermanCulture)} km";
+        AvgMovingTimeText = FormatDuration(snapshot.AverageMovingTime);
+        AvgPaceText = FormatPace(snapshot.AveragePaceSecondsPerKm);
+
+        FastestPaceText = FormatPace(snapshot.FastestPaceSecondsPerKm);
+        MostElevationText = $"{snapshot.MostElevationGainM.ToString("0", GermanCulture)} m";
+        LongestMovingTimeText = FormatDuration(snapshot.LongestMovingTime);
+
+        LevelLabel = gamification.LevelLabel;
+        XpLabel = gamification.XpLabel;
+        LevelProgressFraction = gamification.LevelProgressFraction;
+
+        LongestTripText = $"{snapshot.LongestTripKm.ToString("0.0", GermanCulture)} km";
+        FastestSpeedText = $"{snapshot.FastestAverageSpeedKmh.ToString("0.0", GermanCulture)} km/h";
+        MaxAltitudeText = $"{snapshot.MaxAltitudeM.ToString("0", GermanCulture)} m";
+
+        CoinsEarnedText = snapshot.CoinsEarnedTotal.ToString("N0", GermanCulture);
+        DefenseBestWaveText = snapshot.DefenseBestWave?.ToString(GermanCulture) ?? "-";
+        DefenseBestScoreText = snapshot.DefenseBestScore?.ToString("N0", GermanCulture) ?? "-";
+
+        WeeklyChart.Clear();
+        for (int i = 0; i < snapshot.RecentWeeks.Count; i++)
+        {
+            var week = snapshot.RecentWeeks[i];
+            WeeklyChart.Add(new ChartEntry
+            {
+                Label = week.WeekStart.ToString("dd.MM", GermanCulture),
+                Value = week.DistanceKm,
+                IsHighlighted = i == snapshot.RecentWeeks.Count - 1,
+            });
+        }
+    }
+
+    private static string BuildDeltaText(double deltaKm)
+    {
+        string sign = deltaKm >= 0 ? "+" : "−";
+        return $"{sign}{Math.Abs(deltaKm).ToString("0.0", GermanCulture)} km vs. Vorwoche";
+    }
+
+    private static string FormatDuration(TimeSpan duration) =>
+        duration.TotalHours >= 1
+            ? duration.ToString(@"h\:mm\:ss", GermanCulture)
+            : duration.ToString(@"mm\:ss", GermanCulture);
+
+    private static string FormatPace(double? secondsPerKm)
+    {
+        if (secondsPerKm is not { } s || s <= 0)
+        {
+            return "-";
+        }
+
+        var pace = TimeSpan.FromSeconds(s);
+        return $"{(int)pace.TotalMinutes}:{pace.Seconds:00} /km";
+    }
+}

--- a/UniTracks.ViewModels/Pages/Tabs/UserPagevViewModel.cs
+++ b/UniTracks.ViewModels/Pages/Tabs/UserPagevViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UniTracks.Data.Repository;
 using UniTracks.Models.Trip;
+using UniTracks.Services.Stats;
 using LocationModel = UniTracks.Models.Location.Location;
 
 namespace UniTracks.ViewModels.Pages.Tabs;
@@ -15,12 +16,41 @@ public partial class UserPagevViewModel : ObservableObject
     public INavigationService Navigation { get; }
     public string DatabasePath { get; }
 
-    public UserPagevViewModel(IFileSystem fileSystem, IRepository repository, INavigationService navigation)
+    [ObservableProperty]
+    private string levelText = "-";
+
+    [ObservableProperty]
+    private string streakText = "-";
+
+    [ObservableProperty]
+    private string totalDistanceText = "-";
+
+    public UserPagevViewModel(
+        IFileSystem fileSystem,
+        IRepository repository,
+        INavigationService navigation,
+        IGamificationService gamificationService)
     {
         FileSystem = fileSystem;
         Repository = repository;
         Navigation = navigation;
         DatabasePath = repository.DatabasePath;
+
+        _ = LoadHeroStatsAsync(gamificationService);
+    }
+
+    private async Task LoadHeroStatsAsync(IGamificationService gamificationService)
+    {
+        var stats = await gamificationService.ComputeAsync();
+        LevelText = stats.Level.ToString();
+        StreakText = stats.CurrentStreakDays.ToString();
+        TotalDistanceText = stats.TotalDistanceKm.ToString("0.0");
+    }
+
+    [RelayCommand]
+    private async Task OpenStatistics()
+    {
+        await Navigation.ShellNavigationTo("StatisticsPage", new Dictionary<string, object>());
     }
 
     [RelayCommand]

--- a/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using AgredoApplication.MVVM.Services.Abstractions.Navigation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using UniTracks.Models.Trip;
+using UniTracks.Services.Stats;
 using LocationModel = UniTracks.Models.Location.Location;
 
 namespace UniTracks.ViewModels.Pages;
@@ -39,6 +40,27 @@ public partial class TripOverviewViewModel : ObservableObject
 
     [ObservableProperty]
     private string maxSpeedText = "-";
+
+    [ObservableProperty]
+    private string movingTimeText = "-";
+
+    [ObservableProperty]
+    private string stoppedTimeText = "-";
+
+    [ObservableProperty]
+    private string altitudeText = "-";
+
+    [ObservableProperty]
+    private string paceText = "-";
+
+    [ObservableProperty]
+    private bool hasProfile;
+
+    [ObservableProperty]
+    private IList<double> speedProfile = new List<double>();
+
+    [ObservableProperty]
+    private IList<double> altitudeProfile = new List<double>();
 
     public TripOverviewViewModel(INavigationService navigation)
     {
@@ -91,7 +113,69 @@ public partial class TripOverviewViewModel : ObservableObject
         {
             MaxSpeedText = Math.Round(maxSpeed * 3.6, 1).ToString("0.0", GermanCulture);
         }
+
+        ApplyLocationStats(trip);
     }
+
+    /// <summary>
+    /// Moving/stopped time, altitude range, pace and the speed/altitude profiles are not
+    /// stored on the trip — they are derived from the recorded GPS points.
+    /// </summary>
+    private void ApplyLocationStats(Trip trip)
+    {
+        var locations = trip.Locations?
+            .OrderBy(l => l.Timestamp)
+            .ToList();
+
+        if (locations is null || locations.Count < 2)
+        {
+            return;
+        }
+
+        var (moving, stopped) = TripMetricsCalculator.ComputeMovingAndStopped(locations);
+        MovingTimeText = FormatDuration(moving);
+        StoppedTimeText = FormatDuration(stopped);
+
+        double minAltitude = trip.MinAltitude ?? locations.Min(l => l.Altitude);
+        double maxAltitude = trip.MaxAltitude ?? locations.Max(l => l.Altitude);
+        AltitudeText = $"{Math.Round(minAltitude)}–{Math.Round(maxAltitude)} m";
+
+        double distanceKm = (trip.Distance ?? 0) / 1000.0;
+        if (distanceKm > 0.05 && moving.TotalSeconds > 0)
+        {
+            var pace = TimeSpan.FromSeconds(moving.TotalSeconds / distanceKm);
+            PaceText = $"{(int)pace.TotalMinutes}:{pace.Seconds:00}";
+        }
+
+        BuildProfiles(locations);
+    }
+
+    /// <summary>Resamples the GPS points to at most 100 values so the charts stay cheap to draw.</summary>
+    private void BuildProfiles(List<LocationModel> locations)
+    {
+        const int maxPoints = 100;
+        int stride = Math.Max(1, locations.Count / maxPoints);
+
+        var speeds = new List<double>();
+        var altitudes = new List<double>();
+        for (int i = 0; i < locations.Count; i += stride)
+        {
+            speeds.Add(locations[i].Speed * 3.6);
+            altitudes.Add(locations[i].Altitude);
+        }
+
+        if (speeds.Count >= 2)
+        {
+            SpeedProfile = speeds;
+            AltitudeProfile = altitudes;
+            HasProfile = true;
+        }
+    }
+
+    private static string FormatDuration(TimeSpan duration) =>
+        duration.TotalHours >= 1
+            ? duration.ToString(@"h\:mm\:ss", GermanCulture)
+            : duration.ToString(@"mm\:ss", GermanCulture);
 
     private static string GetTripName(DateTimeOffset startTime)
     {


### PR DESCRIPTION
## Zusammenfassung

Neue **Statistik-Seite** mit schnellem Progress-Überblick, erreichbar über Profil → Statistiken (Hero zeigt Level/Streak/Gesamt-km als Chips).

### Statistiken (Strava-inspiriert)
- **Diese Woche**: Zeit, Distanz, Höhenmeter prominent + Trips, aktive Tage, Streak, Delta zur Vorwoche
- **Durchschnitt pro Trip**: Ø Distanz, Ø Zeit, Ø Pace
- **Dieses Jahr**: km & Trips (YTD)
- **Rekorde**: längster Trip, schnellster Ø-Speed, schnellste Pace, längste Bewegungszeit, max. Höhe, meiste Höhenmeter
- **Spiele**: verdiente Münzen, beste TD-Welle/Score

### Technik
- Eigene wiederverwendbare Chart-Controls (`BarChartView`, `LineChartView`) auf `GraphicsView`-Basis — **keine neue Dependency**
- `TripMetricsCalculator`: geteilte Logik für Bewegungszeit (0,5 m/s-Schwelle) und Höhenmeter (0,5 m Rauschschwelle), genutzt von Statistik **und** Trip-Übersicht
- `TripOverviewPage`: zweite Chip-Reihe (Bewegung/Pause/Höhe/Pace) + Speed-/Höhenprofil-Chart

### Fixes
- `MapView.DrawRoute`: Crash (`IndexOutOfRangeException`) wenn der TrackSmoother alle GPS-Punkte verwirft

### Version
- App-Version auf **0.3** (ApplicationVersion 2) gebumpt

✅ Windows-Build 0 Fehler · ✅ Android-Build 0 Fehler, auf Gerät getestet