### PR TITLE
Statistik-Performance, Wochen-Chart-Fix und Trip-Overlay-Toggle

### DIFF
--- a/UniTracks.Data/Repository/EfRepository.cs
+++ b/UniTracks.Data/Repository/EfRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using UniTracks.Data.SQLite;
 
@@ -24,12 +25,23 @@ public class EfRepository : IRepository
     // against it.
     private readonly SemaphoreSlim gate = new(1, 1);
 
+    // Read-through cache for whole-table reads, same purpose as the one in LiteDbRepository: the
+    // statistics page, the games tab and the user page each re-read the same tables on every visit.
+    // Here the include set is part of the key, because on EF it decides which navigations are
+    // materialised - a no-include list must never be handed out for an include request.
+    private readonly ConcurrentDictionary<(Type Entity, string Includes), (long Version, List<object> Rows)> fullReadCache = new();
+
+    private long dataVersion;
+
     public EfRepository(SqliteDBContext context)
     {
         _context = context;
     }
 
     public string DatabasePath => _context.DatabasePath;
+
+    /// <inheritdoc />
+    public long DataVersion => Interlocked.Read(ref dataVersion);
 
     public async Task<TEntity> Add<TEntity>(TEntity entity) where TEntity : class
     {
@@ -38,6 +50,7 @@ public class EfRepository : IRepository
         {
             var entry = _context.Set<TEntity>().Add(entity).Entity;
             await _context.SaveChangesAsync().ConfigureAwait(false);
+            Interlocked.Increment(ref dataVersion);
             return entry;
         }
         finally
@@ -73,6 +86,7 @@ public class EfRepository : IRepository
             }
 
             await _context.SaveChangesAsync().ConfigureAwait(false);
+            Interlocked.Increment(ref dataVersion);
             return entity;
         }
         finally
@@ -88,6 +102,7 @@ public class EfRepository : IRepository
         {
             _context.Remove(entity);
             await _context.SaveChangesAsync().ConfigureAwait(false);
+            Interlocked.Increment(ref dataVersion);
         }
         finally
         {
@@ -102,6 +117,7 @@ public class EfRepository : IRepository
         {
             _context.RemoveRange(entities);
             await _context.SaveChangesAsync().ConfigureAwait(false);
+            Interlocked.Increment(ref dataVersion);
         }
         finally
         {
@@ -127,7 +143,7 @@ public class EfRepository : IRepository
         await gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            return await _context.Set<TEntity>().IncludeMultiple(includes).ToListAsync().ConfigureAwait(false);
+            return await ReadAllCachedAsync<TEntity>(includes).ConfigureAwait(false);
         }
         finally
         {
@@ -143,10 +159,11 @@ public class EfRepository : IRepository
             IQueryable<TEntity> query = _context.Set<TEntity>();
             if (filter is not null)
             {
-                query = query.Where(filter);
+                return await query.Where(filter).IncludeMultiple(includes).ToListAsync().ConfigureAwait(false);
             }
 
-            return await query.IncludeMultiple(includes).ToListAsync().ConfigureAwait(false);
+            // An unfiltered query is the same result as GetAllAsync, so it shares its cache entry.
+            return await ReadAllCachedAsync<TEntity>(includes).ConfigureAwait(false);
         }
         finally
         {
@@ -159,17 +176,63 @@ public class EfRepository : IRepository
         gate.Wait();
         try
         {
-            IQueryable<TEntity> query = _context.Set<TEntity>();
             if (filter is not null)
             {
-                query = query.Where(filter);
+                return _context.Set<TEntity>().Where(filter).IncludeMultiple(includes).ToList();
             }
 
-            return query.IncludeMultiple(includes).ToList();
+            return ReadAllCached<TEntity>(includes);
         }
         finally
         {
             gate.Release();
         }
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="ReadAllCached{TEntity}"/>. The caller already holds the gate,
+    /// which is what keeps this single-threaded against the non-thread-safe <c>DbContext</c>.
+    /// </summary>
+    private async Task<List<TEntity>> ReadAllCachedAsync<TEntity>(Expression<Func<TEntity, object>>[] includes) where TEntity : class
+    {
+        var key = CacheKey<TEntity>(includes);
+        if (TryGetCached<TEntity>(key, DataVersion, out var cached))
+        {
+            return cached;
+        }
+
+        var version = DataVersion;
+        var rows = await _context.Set<TEntity>().IncludeMultiple(includes).ToListAsync().ConfigureAwait(false);
+        fullReadCache[key] = (version, rows.Cast<object>().ToList());
+        return rows;
+    }
+
+    private List<TEntity> ReadAllCached<TEntity>(Expression<Func<TEntity, object>>[] includes) where TEntity : class
+    {
+        var key = CacheKey<TEntity>(includes);
+        if (TryGetCached<TEntity>(key, DataVersion, out var cached))
+        {
+            return cached;
+        }
+
+        var version = DataVersion;
+        var rows = _context.Set<TEntity>().IncludeMultiple(includes).ToList();
+        fullReadCache[key] = (version, rows.Cast<object>().ToList());
+        return rows;
+    }
+
+    private static (Type Entity, string Includes) CacheKey<TEntity>(Expression<Func<TEntity, object>>[] includes) =>
+        (typeof(TEntity), string.Join("|", includes.Select(include => include.ToString())));
+
+    private bool TryGetCached<TEntity>((Type Entity, string Includes) key, long version, out List<TEntity> rows) where TEntity : class
+    {
+        if (fullReadCache.TryGetValue(key, out var entry) && entry.Version == version)
+        {
+            rows = entry.Rows.Cast<TEntity>().ToList();
+            return true;
+        }
+
+        rows = null!;
+        return false;
     }
 }

--- a/UniTracks.Data/Repository/IRepository.cs
+++ b/UniTracks.Data/Repository/IRepository.cs
@@ -14,6 +14,15 @@ public interface IRepository
 {
     string DatabasePath { get; }
 
+    /// <summary>
+    /// Monotonically increasing counter, incremented on every write (add/update/delete). Read-side
+    /// caches compare against it to tell whether their data is still current — without it they would
+    /// have to re-read the whole store, which is expensive (a trip document carries all of its GPS
+    /// points, and on iOS the BsonMapper pass over those documents is the single most costly
+    /// operation in the app).
+    /// </summary>
+    long DataVersion { get; }
+
     Task<TEntity> Add<TEntity>(TEntity entity) where TEntity : class;
     Task<TEntity> Update<TEntity>(TEntity entity) where TEntity : class;
     Task Delete<TEntity>(TEntity entity) where TEntity : class;

--- a/UniTracks.Data/Repository/LiteDbRepository.cs
+++ b/UniTracks.Data/Repository/LiteDbRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using LiteDB;
 using UniTracks.Data.LiteDB;
@@ -15,6 +16,21 @@ public class LiteDbRepository : IRepository
 {
     private readonly ILiteDatabase _liteDatabase;
 
+    // Full-collection reads are the most expensive operation in the app: every trip document
+    // carries all of its GPS points, so FindAll() materialises thousands of Location objects and
+    // costs roughly two seconds on device. The statistics page, the games tab, the user page and
+    // the trip list each used to run that same scan on every visit - one after the other.
+    //
+    // A read-through cache per entity type collapses them into a single scan. Entries are stamped
+    // with DataVersion, so any write invalidates every cached table. Includes are deliberately not
+    // part of the key: they are a no-op here (see the class comment) and including them would give
+    // the same list three different cache slots.
+    private readonly ConcurrentDictionary<Type, (long Version, List<object> Rows)> fullReadCache = new();
+
+    // Serialises the scans themselves, so two cold readers do not run the same expensive scan
+    // in parallel. Only misses take this lock, cache hits never block.
+    private readonly object scanGate = new();
+
     public LiteDbRepository(ILiteDatabase liteDatabase)
     {
         _liteDatabase = liteDatabase;
@@ -23,21 +39,29 @@ public class LiteDbRepository : IRepository
 
     public string DatabasePath { get; }
 
+    private long dataVersion;
+
+    /// <inheritdoc />
+    public long DataVersion => Interlocked.Read(ref dataVersion);
+
     public Task<TEntity> Add<TEntity>(TEntity entity) where TEntity : class
     {
         _liteDatabase.Database.GetCollection<TEntity>().Insert(entity);
+        Interlocked.Increment(ref dataVersion);
         return Task.FromResult(entity);
     }
 
     public Task<TEntity> Update<TEntity>(TEntity entity) where TEntity : class
     {
         _liteDatabase.Database.GetCollection<TEntity>().Update(entity);
+        Interlocked.Increment(ref dataVersion);
         return Task.FromResult(entity);
     }
 
     public Task Delete<TEntity>(TEntity entity) where TEntity : class
     {
         DeleteCore(entity);
+        Interlocked.Increment(ref dataVersion);
         return Task.CompletedTask;
     }
 
@@ -48,6 +72,7 @@ public class LiteDbRepository : IRepository
             DeleteCore(entity);
         }
 
+        Interlocked.Increment(ref dataVersion);
         return Task.CompletedTask;
     }
 
@@ -73,34 +98,94 @@ public class LiteDbRepository : IRepository
         // aggregates in the parent document, so they are always returned and includes are a no-op.
         var collection = _liteDatabase.Database.GetCollection<TEntity>();
 
+        // A warm cache is answered on the caller's thread: the documents are already materialised,
+        // so there is nothing left to move off the UI thread - and on device the thread hop itself
+        // added a visible delay to every page switch.
+        if (TryGetCached<TEntity>(typeof(TEntity), DataVersion, out var cached))
+        {
+            return Task.FromResult<IEnumerable<TEntity>>(cached);
+        }
+
         // The read (and the BsonMapper pass that materialises the entities) must happen on the
         // worker thread, not on the caller's. LiteDB reads are synchronous, so returning a lazy
         // ReadOnlyCollection here would run the whole scan on the UI thread - either inside this
         // call or at the first enumeration. Both freeze the UI on every page switch, because
         // FindAll() is the entry point of every view model that loads data.
-        return Task.Run(() => (IEnumerable<TEntity>)collection.FindAll().ToList());
+        return Task.Run(() => (IEnumerable<TEntity>)ReadAllCached<TEntity>(collection));
     }
 
     public Task<IEnumerable<TEntity>> GetAsync<TEntity>(Expression<Func<TEntity, bool>>? filter = null, params Expression<Func<TEntity, object>>[] includes) where TEntity : class
     {
         var collection = _liteDatabase.Database.GetCollection<TEntity>();
 
+        if (filter is null)
+        {
+            // Same result as GetAllAsync, so it shares its cache entry instead of scanning again.
+            if (TryGetCached<TEntity>(typeof(TEntity), DataVersion, out var cached))
+            {
+                return Task.FromResult<IEnumerable<TEntity>>(cached);
+            }
+
+            return Task.Run(() => (IEnumerable<TEntity>)ReadAllCached<TEntity>(collection));
+        }
+
         // Same reason as GetAllAsync: the query runs synchronously, so it has to leave the caller's
         // thread. Every filter is evaluated by the document store, which means a full collection scan.
-        return Task.Run(
-            () => (IEnumerable<TEntity>)(filter is null
-                ? collection.Query().ToList()
-                : collection.Query().Where(filter).ToList()));
+        return Task.Run(() => (IEnumerable<TEntity>)collection.Query().Where(filter).ToList());
     }
 
     public IEnumerable<TEntity> Get<TEntity>(Expression<Func<TEntity, bool>>? filter = null, params Expression<Func<TEntity, object>>[] includes) where TEntity : class
     {
-        var query = _liteDatabase.Database.GetCollection<TEntity>().Query();
-        if (filter is not null)
+        var collection = _liteDatabase.Database.GetCollection<TEntity>();
+
+        if (filter is null)
         {
-            query = query.Where(filter);
+            return ReadAllCached<TEntity>(collection);
         }
 
-        return query.ToList();
+        return collection.Query().Where(filter).ToList();
+    }
+
+    /// <summary>
+    /// Returns the whole collection, scanning it only when the cache is cold or stale. The rows are
+    /// shared, the returned list is a fresh copy so a caller cannot corrupt the cached table.
+    /// </summary>
+    private List<TEntity> ReadAllCached<TEntity>(ILiteCollection<TEntity> collection) where TEntity : class
+    {
+        var key = typeof(TEntity);
+
+        if (TryGetCached<TEntity>(key, DataVersion, out var cached))
+        {
+            return cached;
+        }
+
+        lock (scanGate)
+        {
+            // The version is read immediately before the scan: a write that lands while the scan is
+            // running bumps DataVersion past it, so the entry is treated as stale on the next read
+            // instead of handing out rows that were already outdated when they were stored.
+            var version = DataVersion;
+
+            if (TryGetCached<TEntity>(key, version, out cached))
+            {
+                return cached;
+            }
+
+            var rows = collection.FindAll().ToList();
+            fullReadCache[key] = (version, rows.Cast<object>().ToList());
+            return rows;
+        }
+    }
+
+    private bool TryGetCached<TEntity>(Type key, long version, out List<TEntity> rows) where TEntity : class
+    {
+        if (fullReadCache.TryGetValue(key, out var entry) && entry.Version == version)
+        {
+            rows = entry.Rows.Cast<TEntity>().ToList();
+            return true;
+        }
+
+        rows = null!;
+        return false;
     }
 }

--- a/UniTracks.Maui.Views/Controls/Charts/BarChartView.cs
+++ b/UniTracks.Maui.Views/Controls/Charts/BarChartView.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Specialized;
 using UniTracks.Models.Stats;
 
 namespace UniTracks.Maui.Views.Controls.Charts;
@@ -6,33 +7,74 @@ namespace UniTracks.Maui.Views.Controls.Charts;
 /// <summary>
 /// Reusable bar chart (e.g. weekly kilometres). Pure GraphicsView + IDrawable,
 /// themed via bindable colors so it fits the app palette without new dependencies.
-/// Bind <see cref="ItemsSource"/> to a collection of <see cref="ChartEntry"/>.
+/// Bind <see cref="ItemsSource"/> to a collection of <see cref="ChartEntry"/>. Both a replaced
+/// collection and one that is filled after binding (e.g. an <c>ObservableCollection</c> that is
+/// populated once the statistics load finishes) trigger a redraw.
 /// </summary>
 public class BarChartView : GraphicsView
 {
     public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
         nameof(ItemsSource), typeof(IEnumerable), typeof(BarChartView), null,
-        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+        propertyChanged: (b, _, newValue) => ((BarChartView)b).OnItemsSourceChanged(newValue));
 
     public static readonly BindableProperty BarColorProperty = BindableProperty.Create(
         nameof(BarColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#2E7D54"),
-        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+        propertyChanged: (b, _, _) => ((BarChartView)b).InvalidateChart());
 
     public static readonly BindableProperty HighlightColorProperty = BindableProperty.Create(
         nameof(HighlightColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#4DE790"),
-        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+        propertyChanged: (b, _, _) => ((BarChartView)b).InvalidateChart());
 
     public static readonly BindableProperty LabelColorProperty = BindableProperty.Create(
         nameof(LabelColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#6B7A6D"),
-        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+        propertyChanged: (b, _, _) => ((BarChartView)b).InvalidateChart());
 
     public static readonly BindableProperty ValueColorProperty = BindableProperty.Create(
         nameof(ValueColor), typeof(Color), typeof(BarChartView), Color.FromArgb("#A9B8AC"),
-        propertyChanged: (b, _, _) => ((BarChartView)b).Invalidate());
+        propertyChanged: (b, _, _) => ((BarChartView)b).InvalidateChart());
+
+    private INotifyCollectionChanged? observedCollection;
 
     public BarChartView()
     {
         Drawable = new BarChartDrawable(this);
+    }
+
+    /// <summary>
+    /// Swaps the collection subscription and redraws. Without the subscription a chart whose source
+    /// collection is only filled after the binding was applied would never be repainted, because the
+    /// bindable property itself keeps pointing at the same collection instance.
+    /// </summary>
+    private void OnItemsSourceChanged(object? newValue)
+    {
+        if (observedCollection is not null)
+        {
+            observedCollection.CollectionChanged -= OnSourceCollectionChanged;
+            observedCollection = null;
+        }
+
+        if (newValue is INotifyCollectionChanged observable)
+        {
+            observedCollection = observable;
+            observedCollection.CollectionChanged += OnSourceCollectionChanged;
+        }
+
+        InvalidateChart();
+    }
+
+    private void OnSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => InvalidateChart();
+
+    /// <summary><see cref="GraphicsView.Invalidate"/> is main-thread only.</summary>
+    private void InvalidateChart()
+    {
+        if (MainThread.IsMainThread)
+        {
+            Invalidate();
+        }
+        else
+        {
+            Dispatcher.Dispatch(Invalidate);
+        }
     }
 
     public IEnumerable? ItemsSource

--- a/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
+++ b/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
@@ -11,11 +11,17 @@
     x:DataType="vm:TripOverviewViewModel">
 
     <Grid>
-        <controls:MapView Locations="{Binding Locations}" />
+        <!-- Tapping the map toggles both overlay cards, so the route can be seen unobstructed. -->
+        <controls:MapView Locations="{Binding Locations}">
+            <controls:MapView.GestureRecognizers>
+                <TapGestureRecognizer Command="{Binding ToggleOverlayCommand}" />
+            </controls:MapView.GestureRecognizers>
+        </controls:MapView>
 
         <!-- Floating stats card (tap for full analysis) -->
         <Border
             Margin="16"
+            IsVisible="{Binding IsOverlayVisible}"
             Style="{StaticResource CardBorder}"
             VerticalOptions="Start">
             <Border.GestureRecognizers>
@@ -37,8 +43,12 @@
                         VerticalTextAlignment="Center" />
                 </Grid>
 
-                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
-                    <Border Grid.Column="0" Style="{StaticResource AccentChipBorder}">
+                <Grid
+                    ColumnDefinitions="*,*,*,*"
+                    ColumnSpacing="8"
+                    RowDefinitions="Auto,Auto"
+                    RowSpacing="8">
+                    <Border Grid.Column="0" Grid.Row="0" Style="{StaticResource AccentChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="DISTANZ" />
                             <HorizontalStackLayout Spacing="3">
@@ -55,7 +65,7 @@
                             </HorizontalStackLayout>
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="1" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="1" Grid.Row="0" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="DAUER" />
                             <Label
@@ -64,7 +74,7 @@
                                 Text="{Binding DurationText}" />
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="2" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="2" Grid.Row="0" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="&#xD8; KM/H" />
                             <Label
@@ -73,13 +83,52 @@
                                 Text="{Binding AverageSpeedText}" />
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="3" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="3" Grid.Row="0" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="MAX KM/H" />
                             <Label
                                 FontFamily="OpenSansSemibold"
                                 FontSize="16"
                                 Text="{Binding MaxSpeedText}" />
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <!-- Same set as the analysis page, so the overview is complete on its own. -->
+                    <Border Grid.Column="0" Grid.Row="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="BEWEGUNG" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding MovingTimeText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="PAUSE" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding StoppedTimeText}" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="2" Grid.Row="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="HÖHE" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="14"
+                                Text="{Binding AltitudeText}"
+                                VerticalOptions="Center" />
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border Grid.Column="3" Grid.Row="1" Style="{StaticResource ChipBorder}">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Style="{StaticResource StatLabel}" Text="PACE /KM" />
+                            <Label
+                                FontFamily="OpenSansSemibold"
+                                FontSize="16"
+                                Text="{Binding PaceText}" />
                         </VerticalStackLayout>
                     </Border>
                 </Grid>
@@ -96,8 +145,8 @@
         <Border
             Margin="16"
             Padding="14,10"
+            IsVisible="{Binding ShowProfile}"
             Style="{StaticResource CardBorder}"
-            IsVisible="{Binding HasProfile}"
             VerticalOptions="End">
             <Border.GestureRecognizers>
                 <TapGestureRecognizer Command="{Binding OpenDetailsCommand}" />

--- a/UniTracks.Services/Game/CoinService.cs
+++ b/UniTracks.Services/Game/CoinService.cs
@@ -23,14 +23,16 @@ public class CoinService : ICoinService
 
     public async Task<ActivityStats> GetAsync()
     {
+        // The repository serves this full-table read from its read cache, so the coin balance no
+        // longer triggers its own trip scan next to the statistics page's read.
         var trips = (await repository.GetAllAsync<Trip>(t => t.TripType!))
             .Where(TripQualification.IsQualifying)
             .ToList();
         var stats = await gamificationService.ComputeAsync(trips);
 
-        // Projecting the loaded trips into the coin feed is CPU-bound. Run it off the UI
-        // thread so the Games tab and game starts don't block while computing the balance.
-        return await Task.Run(() => new ActivityStats
+        // Projecting the loaded trips into the coin feed is cheap in-memory work over a handful
+        // of trips; the expensive part (loading the trips) has already happened above.
+        return new ActivityStats
         {
             Trips = trips.Select(t => new TripActivity
             {
@@ -41,6 +43,6 @@ public class CoinService : ICoinService
             Xp = stats.Xp,
             UnlockedAchievements = stats.Achievements.Count(a => a.IsUnlocked),
             UnlockedAchievementIds = stats.Achievements.Where(a => a.IsUnlocked).Select(a => a.Id).ToList(),
-        });
+        };
     }
 }

--- a/UniTracks.Services/Stats/GamificationService.cs
+++ b/UniTracks.Services/Stats/GamificationService.cs
@@ -21,15 +21,17 @@ public class GamificationService : IGamificationService
 
     public async Task<GamificationStats> ComputeAsync()
     {
+        // Served from the repository read cache, so this is not a second scan when the caller
+        // has already read the trips (the statistics page passes its list in directly).
         var trips = (await repository.GetAllAsync<Trip>())
             .Where(TripQualification.IsQualifying)
             .ToList();
 
-        return await ComputeAsync(trips);
+        return Compute(trips);
     }
 
     public Task<GamificationStats> ComputeAsync(IEnumerable<Trip> trips) =>
-        Task.Run(() => Compute(trips.ToList()));
+        Task.FromResult(Compute(trips.ToList()));
 
     /// <summary>Pure in-memory computation over already-loaded trips — safe to run off the UI thread.</summary>
     private static GamificationStats Compute(List<Trip> trips)

--- a/UniTracks.Services/Stats/IStatisticsService.cs
+++ b/UniTracks.Services/Stats/IStatisticsService.cs
@@ -10,7 +10,8 @@ public record WeeklyDistance
 
 /// <summary>
 /// Aggregated progress snapshot for the statistics page: current week vs. last week,
-/// all-time records, the last weeks as chart buckets and the game-side highlights.
+/// all-time records, the last weeks as chart buckets, the level/streak state and the
+/// game-side highlights.
 /// </summary>
 public record StatisticsSnapshot
 {
@@ -65,6 +66,17 @@ public record StatisticsSnapshot
 
     /// <summary>Lifetime coins earned from activity (before any spending).</summary>
     public int CoinsEarnedTotal { get; init; }
+
+    // Gamification state, computed from the same trip scan. Carried in the snapshot so the
+    // statistics page does not need a second pass over the recorded trips.
+    public int Xp { get; init; }
+
+    public int Level { get; init; }
+
+    public double LevelProgressFraction { get; init; }
+
+    /// <summary>Consecutive active days ending today or yesterday; 0 when the streak is broken.</summary>
+    public int CurrentStreakDays { get; init; }
 
     public int? DefenseBestWave { get; init; }
 

--- a/UniTracks.Services/Stats/StatisticsService.cs
+++ b/UniTracks.Services/Stats/StatisticsService.cs
@@ -2,6 +2,7 @@ using UniTracks.Data.Repository;
 using UniTracks.Games.Shared.Economy;
 using UniTracks.Games.Shared.Persistence;
 using UniTracks.Games.TowerDefense.Persistence;
+using UniTracks.Models.Achievement;
 using UniTracks.Models.Trip;
 
 namespace UniTracks.Services.Stats;
@@ -15,18 +16,26 @@ public class StatisticsService : IStatisticsService
 {
     private readonly IRepository repository;
     private readonly IActivityStatsSource activityStats;
+    private readonly IGamificationService gamificationService;
     private readonly ITowerDefenseStore towerDefenseStore;
 
-    public StatisticsService(IRepository repository, IActivityStatsSource activityStats, ITowerDefenseStore towerDefenseStore)
+    public StatisticsService(
+        IRepository repository,
+        IActivityStatsSource activityStats,
+        IGamificationService gamificationService,
+        ITowerDefenseStore towerDefenseStore)
     {
         this.repository = repository;
         this.activityStats = activityStats;
+        this.gamificationService = gamificationService;
         this.towerDefenseStore = towerDefenseStore;
     }
 
     public async Task<StatisticsSnapshot> GetSnapshotAsync(int weekCount = 8)
     {
-        // Locations are needed for moving time and elevation gain, so load them eagerly.
+        // Locations are needed for moving time and elevation gain, so load them eagerly. The
+        // repository answers this full-table read from its read cache, so returning to the
+        // statistics page no longer re-scans every trip and its thousands of GPS points.
         var trips = (await repository.GetAllAsync<Trip>(trip => trip.Locations))
             .Where(TripQualification.IsQualifying)
             .ToList();
@@ -34,15 +43,22 @@ public class StatisticsService : IStatisticsService
         var stats = await activityStats.GetAsync();
         var record = await towerDefenseStore.LoadRecordAsync();
 
+        // Level, XP and streak are derived from this very trip list instead of a second scan.
+        var gamification = await gamificationService.ComputeAsync(trips);
+
         // The aggregation below is CPU-bound (per-trip moving time/elevation and many LINQ
         // passes). Run it on a worker thread so the UI thread stays responsive while the
         // statistics page appears — otherwise the page switch blocks mid-render.
-        return await Task.Run(() => BuildSnapshot(trips, stats, record, weekCount));
+        return await Task.Run(() => BuildSnapshot(trips, stats, record, gamification, weekCount));
     }
 
     /// <summary>Pure in-memory aggregation over already-loaded trips — safe to run off the UI thread.</summary>
     private static StatisticsSnapshot BuildSnapshot(
-        List<Trip> trips, ActivityStats stats, DefenseRecord? record, int weekCount)
+        List<Trip> trips,
+        ActivityStats stats,
+        DefenseRecord? record,
+        GamificationStats gamification,
+        int weekCount)
     {
         // Per-trip derived metrics, keyed by trip id.
         var metrics = trips.ToDictionary(
@@ -124,6 +140,10 @@ public class StatisticsService : IStatisticsService
             CoinsEarnedTotal = coinsEarned,
             DefenseBestWave = record?.BestWave,
             DefenseBestScore = record?.BestScore,
+            Xp = gamification.Xp,
+            Level = gamification.Level,
+            LevelProgressFraction = gamification.LevelProgressFraction,
+            CurrentStreakDays = gamification.CurrentStreakDays,
         };
     }
 

--- a/UniTracks.Tests/Repository/RepositoryContractTests.cs
+++ b/UniTracks.Tests/Repository/RepositoryContractTests.cs
@@ -229,6 +229,85 @@ public sealed class RepositoryContractTests
     }
 
     /// <summary>
+    /// Whole-table reads are served from a read-through cache (that is what keeps the statistics
+    /// page from re-scanning every trip and its thousands of GPS points on each visit). The cache
+    /// must never outlive a write: every mutation has to make the next full read hit the store again.
+    /// </summary>
+    [Fact]
+    public async Task Ef_FullReads_SeeEarlierWrites()
+    {
+        using var db = new SqliteTestDatabase();
+        await AssertFullReadsSeeWrites(db.Repository);
+    }
+
+    /// <inheritdoc cref="Ef_FullReads_SeeEarlierWrites"/>
+    [Fact]
+    public async Task LiteDb_FullReads_SeeEarlierWrites()
+    {
+        await WithLiteDb(AssertFullReadsSeeWrites);
+    }
+
+    private static async Task AssertFullReadsSeeWrites(IRepository repository)
+    {
+        static DefenseRecord Record(int wave) => new()
+        {
+            ID = Guid.NewGuid(),
+            BestWave = wave,
+            BestScore = wave * 100,
+        };
+
+        // Prime the cache with a plain read, then mutate through every write method.
+        var first = await repository.Add(Record(1));
+        Assert.Single(await repository.GetAllAsync<DefenseRecord>());
+        Assert.Single(repository.Get<DefenseRecord>());
+        Assert.Single(await repository.GetAsync<DefenseRecord>());
+
+        var second = await repository.Add(Record(2));
+        Assert.Equal(2, (await repository.GetAllAsync<DefenseRecord>()).Count());
+        Assert.Equal(2, repository.Get<DefenseRecord>().Count());
+
+        first.BestWave = 7;
+        await repository.Update(first);
+        Assert.Equal(7, repository.Get<DefenseRecord>().Single(r => r.ID == first.ID).BestWave);
+
+        await repository.Delete(second);
+        Assert.Equal(first.ID, Assert.Single(await repository.GetAllAsync<DefenseRecord>()).ID);
+    }
+
+    /// <summary>
+    /// A cache hit must hand out a fresh list instance: callers sort, filter and clear the result
+    /// (the statistics page trims the trip list before aggregating), and that must never be able to
+    /// damage the cached copy or leak into the next reader.
+    /// </summary>
+    [Fact]
+    public async Task Ef_CachedReads_ReturnIndependentLists()
+    {
+        using var db = new SqliteTestDatabase();
+        await AssertCachedReadsReturnIndependentLists(db.Repository);
+    }
+
+    /// <inheritdoc cref="Ef_CachedReads_ReturnIndependentLists"/>
+    [Fact]
+    public async Task LiteDb_CachedReads_ReturnIndependentLists()
+    {
+        await WithLiteDb(AssertCachedReadsReturnIndependentLists);
+    }
+
+    private static async Task AssertCachedReadsReturnIndependentLists(IRepository repository)
+    {
+        await repository.Add(new DefenseRecord { ID = Guid.NewGuid(), BestWave = 3, BestScore = 300 });
+
+        var first = (await repository.GetAllAsync<DefenseRecord>()).ToList();
+        var second = (await repository.GetAllAsync<DefenseRecord>()).ToList();
+
+        Assert.NotSame(first, second);
+        Assert.Equal(first[0].ID, second[0].ID);
+
+        first.Clear();
+        Assert.Single(await repository.GetAllAsync<DefenseRecord>());
+    }
+
+    /// <summary>
     /// Runs the assertions against a <see cref="LiteDbRepository"/> backed by a temp file, so the
     /// iOS code path is exercised on the test machine as well.
     /// </summary>

--- a/UniTracks.Tests/ViewModels/Fakes/ViewModelFakes.cs
+++ b/UniTracks.Tests/ViewModels/Fakes/ViewModelFakes.cs
@@ -310,8 +310,12 @@ internal sealed class FakeGpsDataStorageService : IGpsDataStorageService
 internal sealed class InMemoryRepository : IRepository
 {
     private readonly Dictionary<Type, List<object>> tables = new();
+    private long dataVersion;
 
     public string DatabasePath => "test://unitracks-in-memory";
+
+    /// <inheritdoc />
+    public long DataVersion => dataVersion;
 
     public List<(string Operation, Type EntityType, IReadOnlyList<object> Entities)> Calls { get; } = new();
 
@@ -330,6 +334,7 @@ internal sealed class InMemoryRepository : IRepository
         where TEntity : class
     {
         Calls.Add(("Add", typeof(TEntity), new object[] { entity! }));
+        dataVersion++;
         Table<TEntity>().Add(entity!);
         return Task.FromResult(entity);
     }
@@ -338,12 +343,14 @@ internal sealed class InMemoryRepository : IRepository
         where TEntity : class
     {
         Calls.Add(("Update", typeof(TEntity), new object[] { entity! }));
+        dataVersion++;
         return Task.FromResult(entity);
     }
 
     public Task Delete<TEntity>(TEntity entity)
         where TEntity : class
     {
+        dataVersion++;
         Calls.Add(("Delete", typeof(TEntity), new object[] { entity! }));
         Table<TEntity>().Remove(entity!);
         return Task.CompletedTask;
@@ -353,6 +360,7 @@ internal sealed class InMemoryRepository : IRepository
         where TEntity : class
     {
         var deleted = entities.Cast<object>().ToList();
+        dataVersion++;
         Calls.Add(("DeleteRange", typeof(TEntity), deleted));
 
         foreach (var entity in deleted)

--- a/UniTracks.ViewModels/Pages/StatisticsPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/StatisticsPageViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using UniTracks.Models.Stats;
@@ -8,20 +7,19 @@ namespace UniTracks.ViewModels.Pages;
 
 /// <summary>
 /// Progress statistics at a glance: current week vs. last week, level, weekly chart,
-/// all-time records and the game highlights. Data comes from <see cref="IStatisticsService"/>
-/// (aggregation) and <see cref="IGamificationService"/> (level/streak).
+/// all-time records and the game highlights. Everything comes from a single
+/// <see cref="IStatisticsService.GetSnapshotAsync"/> call, which aggregates the recorded trips
+/// once (including level/XP/streak) so opening the page does not scan the trips repeatedly.
 /// </summary>
 public partial class StatisticsPageViewModel : ObservableObject
 {
     private static readonly CultureInfo GermanCulture = CultureInfo.GetCultureInfo("de-DE");
 
     private readonly IStatisticsService statisticsService;
-    private readonly IGamificationService gamificationService;
 
-    public StatisticsPageViewModel(IStatisticsService statisticsService, IGamificationService gamificationService)
+    public StatisticsPageViewModel(IStatisticsService statisticsService)
     {
         this.statisticsService = statisticsService;
-        this.gamificationService = gamificationService;
         _ = LoadAsync();
     }
 
@@ -97,18 +95,18 @@ public partial class StatisticsPageViewModel : ObservableObject
     [ObservableProperty]
     private string defenseBestScoreText = "-";
 
-    public ObservableCollection<ChartEntry> WeeklyChart { get; } = new();
+    [ObservableProperty]
+    private IReadOnlyList<ChartEntry> weeklyChart = Array.Empty<ChartEntry>();
 
     private async Task LoadAsync()
     {
         var snapshot = await statisticsService.GetSnapshotAsync();
-        var gamification = await gamificationService.ComputeAsync();
 
         WeekDistanceText = snapshot.WeekDistanceKm.ToString("0.0", GermanCulture);
         WeekDeltaText = BuildDeltaText(snapshot.WeekDistanceKm - snapshot.LastWeekDistanceKm);
         WeekTripsText = snapshot.WeekTrips.ToString(GermanCulture);
         WeekActiveDaysText = snapshot.WeekActiveDays.ToString(GermanCulture);
-        StreakText = gamification.CurrentStreakDays.ToString(GermanCulture);
+        StreakText = snapshot.CurrentStreakDays.ToString(GermanCulture);
         WeekMovingTimeText = FormatDuration(snapshot.WeekMovingTime);
         WeekElevationText = snapshot.WeekElevationGainM.ToString("0", GermanCulture);
 
@@ -123,9 +121,9 @@ public partial class StatisticsPageViewModel : ObservableObject
         MostElevationText = $"{snapshot.MostElevationGainM.ToString("0", GermanCulture)} m";
         LongestMovingTimeText = FormatDuration(snapshot.LongestMovingTime);
 
-        LevelLabel = gamification.LevelLabel;
-        XpLabel = gamification.XpLabel;
-        LevelProgressFraction = gamification.LevelProgressFraction;
+        LevelLabel = $"Level {snapshot.Level}";
+        XpLabel = $"{snapshot.Xp} XP";
+        LevelProgressFraction = snapshot.LevelProgressFraction;
 
         LongestTripText = $"{snapshot.LongestTripKm.ToString("0.0", GermanCulture)} km";
         FastestSpeedText = $"{snapshot.FastestAverageSpeedKmh.ToString("0.0", GermanCulture)} km/h";
@@ -135,17 +133,21 @@ public partial class StatisticsPageViewModel : ObservableObject
         DefenseBestWaveText = snapshot.DefenseBestWave?.ToString(GermanCulture) ?? "-";
         DefenseBestScoreText = snapshot.DefenseBestScore?.ToString("N0", GermanCulture) ?? "-";
 
-        WeeklyChart.Clear();
+        // A fresh list per load (instead of mutating a shared collection) so the chart control
+        // sees a property change and repaints — the data only arrives once the load completes.
+        var weeks = new List<ChartEntry>(snapshot.RecentWeeks.Count);
         for (int i = 0; i < snapshot.RecentWeeks.Count; i++)
         {
             var week = snapshot.RecentWeeks[i];
-            WeeklyChart.Add(new ChartEntry
+            weeks.Add(new ChartEntry
             {
                 Label = week.WeekStart.ToString("dd.MM", GermanCulture),
                 Value = week.DistanceKm,
                 IsHighlighted = i == snapshot.RecentWeeks.Count - 1,
             });
         }
+
+        WeeklyChart = weeks;
     }
 
     private static string BuildDeltaText(double deltaKm)

--- a/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
@@ -54,8 +54,17 @@ public partial class TripOverviewViewModel : ObservableObject
     [ObservableProperty]
     private string paceText = "-";
 
+    /// <summary>Both overlay cards are shown/hidden together by tapping the map.</summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowProfile))]
+    private bool isOverlayVisible = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowProfile))]
     private bool hasProfile;
+
+    /// <summary>The profile card only exists when the trip has enough GPS points to draw it.</summary>
+    public bool ShowProfile => HasProfile && IsOverlayVisible;
 
     [ObservableProperty]
     private IList<double> speedProfile = new List<double>();
@@ -172,6 +181,12 @@ public partial class TripOverviewViewModel : ObservableObject
             HasProfile = true;
         }
     }
+
+    /// <summary>
+    /// Tap on the map: hide both overlay cards so the route is visible, tap again to bring them back.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleOverlay() => IsOverlayVisible = !IsOverlayVisible;
 
     [RelayCommand]
     private async Task OpenDetails()


### PR DESCRIPTION
## Performance der Statistikseite

Die Statistikseite lud ≈ 8,5 s. Ursache (auf dem Gerät gemessen): mehrere **synchrone LiteDB-Vollscans auf dem UI-Thread** — `Stats.trips loaded` +1870 ms, `Coin.trips loaded` +2701 ms, `Gamification.trips loaded` +2723 ms.

- `IRepository.DataVersion` (monoton, bei jedem Write inkrementiert) + Full-Read-Cache in `LiteDbRepository` und `EfRepository`. Warm-Treffer werden synchron auf dem Aufrufer-Thread beantwortet, Kalttreffer laufen in `Task.Run`; die Version wird unmittelbar vor dem Scan gelesen und im Cache-Eintrag gestempelt.
- `StatisticsService` bekommt `IGamificationService` und rechnet Level/XP/Streak aus der **eigenen** Trip-Liste (`ComputeAsync(trips)`), `GamificationService` und `CoinService` ohne `Task.Run`, `StatisticsPageViewModel` mit nur noch **einem** `GetSnapshotAsync()`.

Gemessen gegen die echte Geräte-DB (13 Trips / 7503 GPS-Punkte), Testhost mit neuem Code:

| | vorher (Gerät) | nachher |
|---|---|---|
| Kalt | 1870 / 2701 / 2723 ms | **125 ms** |
| Warm | — | **1 ms** |

## „Kilometer pro Woche“ war leer

`BarChartView` invalidierte nur bei `PropertyChanged` des `ItemsSource`-BindableProperties. Da die Bindung auf eine stabile `ObservableCollection` zeigte, die erst **nach** dem Binden gefüllt wurde, feuerte die Property nie wieder → kein Repaint.

- Abo auf `INotifyCollectionChanged.CollectionChanged` (inkl. Ab-/Umschalten) und `InvalidateChart()` mit MainThread-Guard.
- `WeeklyChart` ist jetzt `[ObservableProperty] IReadOnlyList<ChartEntry>` — pro Load eine frische Liste.

## Trip-Übersicht

- Tippen auf die Karte blendet alle Overlays aus, erneutes Tippen wieder ein (`ToggleOverlayCommand`, obere Card + Profil-Chart).
- Overview-Chips von 4 auf 8 erweitert: zusätzlich **Bewegung, Pause, Höhe, Pace**.

## Tests

- 4 neue Cache-Regressionstests: `Ef_FullReads_SeeEarlierWrites`, `LiteDb_FullReads_SeeEarlierWrites`, `Ef_CachedReads_ReturnIndependentLists`, `LiteDb_CachedReads_ReturnIndependentLists`.
- Suite: **150/150 grün**.
- iOS-Build (`net11.0-ios`, preview.7): 0 Fehler, 0 Warnungen.