### PR TITLE
Trip-Analyse: alle Statistik-Chips sichtbar, Overlay wieder schlank

### DIFF
--- a/UniTracks.Maui.Views/Pages/TripChartsPage.xaml
+++ b/UniTracks.Maui.Views/Pages/TripChartsPage.xaml
@@ -20,7 +20,13 @@
             <!-- All stats -->
             <VerticalStackLayout Spacing="8">
                 <Label Style="{StaticResource SectionHeader}" Text="STATISTIKEN" />
-                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8" RowSpacing="8">
+                <!-- RowDefinitions is required: MAUI clamps Grid.Row to the last defined row,
+                     so without it the second row of chips would be drawn on top of the first. -->
+                <Grid
+                    ColumnDefinitions="*,*,*,*"
+                    ColumnSpacing="8"
+                    RowDefinitions="Auto,Auto"
+                    RowSpacing="8">
                     <Border Grid.Column="0" Grid.Row="0" Style="{StaticResource AccentChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="DISTANZ" />

--- a/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
+++ b/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
@@ -43,12 +43,8 @@
                         VerticalTextAlignment="Center" />
                 </Grid>
 
-                <Grid
-                    ColumnDefinitions="*,*,*,*"
-                    ColumnSpacing="8"
-                    RowDefinitions="Auto,Auto"
-                    RowSpacing="8">
-                    <Border Grid.Column="0" Grid.Row="0" Style="{StaticResource AccentChipBorder}">
+                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
+                    <Border Grid.Column="0" Style="{StaticResource AccentChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="DISTANZ" />
                             <HorizontalStackLayout Spacing="3">
@@ -65,7 +61,7 @@
                             </HorizontalStackLayout>
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="1" Grid.Row="0" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="1" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="DAUER" />
                             <Label
@@ -74,7 +70,7 @@
                                 Text="{Binding DurationText}" />
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="2" Grid.Row="0" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="2" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="&#xD8; KM/H" />
                             <Label
@@ -83,52 +79,13 @@
                                 Text="{Binding AverageSpeedText}" />
                         </VerticalStackLayout>
                     </Border>
-                    <Border Grid.Column="3" Grid.Row="0" Style="{StaticResource ChipBorder}">
+                    <Border Grid.Column="3" Style="{StaticResource ChipBorder}">
                         <VerticalStackLayout Spacing="2">
                             <Label Style="{StaticResource StatLabel}" Text="MAX KM/H" />
                             <Label
                                 FontFamily="OpenSansSemibold"
                                 FontSize="16"
                                 Text="{Binding MaxSpeedText}" />
-                        </VerticalStackLayout>
-                    </Border>
-
-                    <!-- Same set as the analysis page, so the overview is complete on its own. -->
-                    <Border Grid.Column="0" Grid.Row="1" Style="{StaticResource ChipBorder}">
-                        <VerticalStackLayout Spacing="2">
-                            <Label Style="{StaticResource StatLabel}" Text="BEWEGUNG" />
-                            <Label
-                                FontFamily="OpenSansSemibold"
-                                FontSize="16"
-                                Text="{Binding MovingTimeText}" />
-                        </VerticalStackLayout>
-                    </Border>
-                    <Border Grid.Column="1" Grid.Row="1" Style="{StaticResource ChipBorder}">
-                        <VerticalStackLayout Spacing="2">
-                            <Label Style="{StaticResource StatLabel}" Text="PAUSE" />
-                            <Label
-                                FontFamily="OpenSansSemibold"
-                                FontSize="16"
-                                Text="{Binding StoppedTimeText}" />
-                        </VerticalStackLayout>
-                    </Border>
-                    <Border Grid.Column="2" Grid.Row="1" Style="{StaticResource ChipBorder}">
-                        <VerticalStackLayout Spacing="2">
-                            <Label Style="{StaticResource StatLabel}" Text="HÖHE" />
-                            <Label
-                                FontFamily="OpenSansSemibold"
-                                FontSize="14"
-                                Text="{Binding AltitudeText}"
-                                VerticalOptions="Center" />
-                        </VerticalStackLayout>
-                    </Border>
-                    <Border Grid.Column="3" Grid.Row="1" Style="{StaticResource ChipBorder}">
-                        <VerticalStackLayout Spacing="2">
-                            <Label Style="{StaticResource StatLabel}" Text="PACE /KM" />
-                            <Label
-                                FontFamily="OpenSansSemibold"
-                                FontSize="16"
-                                Text="{Binding PaceText}" />
                         </VerticalStackLayout>
                     </Border>
                 </Grid>

--- a/UniTracks.Tests/Views/XamlGridLayoutTests.cs
+++ b/UniTracks.Tests/Views/XamlGridLayoutTests.cs
@@ -1,0 +1,101 @@
+using System.Xml.Linq;
+
+namespace UniTracks.Tests.Views;
+
+/// <summary>
+/// MAUI clamps <c>Grid.Row</c>/<c>Grid.Column</c> to the last defined row/column
+/// (<c>GridLayoutManager</c> falls back to a single implied star definition when the collection is
+/// empty), so a Grid without enough <c>RowDefinitions</c>/<c>ColumnDefinitions</c> silently stacks
+/// its children on top of each other instead of laying them out.
+/// <para>
+/// That is how the trip analysis page lost half of its statistic chips: the chip grid declared four
+/// columns, four chips in row 1 and no row definitions, so the second row was drawn over the first.
+/// </para>
+/// </summary>
+public sealed class XamlGridLayoutTests
+{
+    private static readonly XNamespace Maui = "http://schemas.microsoft.com/dotnet/2021/maui";
+
+    [Fact]
+    public void EveryGrid_DeclaresEnoughRowsAndColumnsForItsChildren()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in XamlFiles())
+        {
+            XDocument document;
+            try
+            {
+                document = XDocument.Load(file);
+            }
+            catch (Exception exception)
+            {
+                offenders.Add($"{Relative(file)}: nicht lesbar ({exception.Message})");
+                continue;
+            }
+
+            foreach (var grid in document.Descendants(Maui + "Grid"))
+            {
+                int rows = DefinitionCount(grid.Attribute("RowDefinitions"));
+                int columns = DefinitionCount(grid.Attribute("ColumnDefinitions"));
+
+                int maxRow = MaxIndex(grid, "Grid.Row");
+                int maxColumn = MaxIndex(grid, "Grid.Column");
+
+                if (maxRow >= rows)
+                {
+                    offenders.Add($"{Relative(file)}: Grid.Row=\"{maxRow}\" ohne RowDefinitions ({rows} Zeilen)");
+                }
+
+                if (maxColumn >= columns)
+                {
+                    offenders.Add($"{Relative(file)}: Grid.Column=\"{maxColumn}\" ohne ColumnDefinitions ({columns} Spalten)");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0, string.Join(Environment.NewLine, offenders));
+    }
+
+    private static IEnumerable<string> XamlFiles() =>
+        Directory.EnumerateFiles(
+            Path.Combine(RepositoryRoot(), "UniTracks.Maui.Views"),
+            "*.xaml",
+            SearchOption.AllDirectories);
+
+    /// <summary>Counts the definitions in an attribute such as <c>"Auto,Auto"</c> or <c>"*,2*"</c>.</summary>
+    private static int DefinitionCount(XAttribute? attribute) =>
+        attribute is null
+            ? 0
+            : attribute.Value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length;
+
+    /// <summary>Largest index used by a direct child, or -1 when no child sets the attached property.</summary>
+    private static int MaxIndex(XElement grid, string attribute)
+    {
+        int maximum = -1;
+        foreach (var child in grid.Elements())
+        {
+            if (int.TryParse(child.Attribute(attribute)?.Value, out int index))
+            {
+                maximum = Math.Max(maximum, index);
+            }
+        }
+
+        return maximum;
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !Directory.Exists(Path.Combine(directory.FullName, "UniTracks.Maui.Views")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException($"Repository-Wurzel über {AppContext.BaseDirectory} nicht gefunden.");
+    }
+
+    private static string Relative(string file) =>
+        Path.GetRelativePath(RepositoryRoot(), file).Replace('\\', '/');
+}

--- a/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
+++ b/UniTracks.ViewModels/Pages/TripOverviewViewModel.cs
@@ -4,7 +4,6 @@ using AgredoApplication.MVVM.Services.Abstractions.Navigation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using UniTracks.Models.Trip;
-using UniTracks.Services.Stats;
 using LocationModel = UniTracks.Models.Location.Location;
 
 namespace UniTracks.ViewModels.Pages;
@@ -41,18 +40,6 @@ public partial class TripOverviewViewModel : ObservableObject
 
     [ObservableProperty]
     private string maxSpeedText = "-";
-
-    [ObservableProperty]
-    private string movingTimeText = "-";
-
-    [ObservableProperty]
-    private string stoppedTimeText = "-";
-
-    [ObservableProperty]
-    private string altitudeText = "-";
-
-    [ObservableProperty]
-    private string paceText = "-";
 
     /// <summary>Both overlay cards are shown/hidden together by tapping the map.</summary>
     [ObservableProperty]
@@ -128,8 +115,8 @@ public partial class TripOverviewViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Moving/stopped time, altitude range, pace and the speed/altitude profiles are not
-    /// stored on the trip — they are derived from the recorded GPS points.
+    /// The speed/altitude profile is not stored on the trip — it is derived from the
+    /// recorded GPS points. The full set of derived metrics lives on the analysis page.
     /// </summary>
     private void ApplyLocationStats(Trip trip)
     {
@@ -140,21 +127,6 @@ public partial class TripOverviewViewModel : ObservableObject
         if (locations is null || locations.Count < 2)
         {
             return;
-        }
-
-        var (moving, stopped) = TripMetricsCalculator.ComputeMovingAndStopped(locations);
-        MovingTimeText = FormatDuration(moving);
-        StoppedTimeText = FormatDuration(stopped);
-
-        double minAltitude = trip.MinAltitude ?? locations.Min(l => l.Altitude);
-        double maxAltitude = trip.MaxAltitude ?? locations.Max(l => l.Altitude);
-        AltitudeText = $"{Math.Round(minAltitude)}–{Math.Round(maxAltitude)} m";
-
-        double distanceKm = (trip.Distance ?? 0) / 1000.0;
-        if (distanceKm > 0.05 && moving.TotalSeconds > 0)
-        {
-            var pace = TimeSpan.FromSeconds(moving.TotalSeconds / distanceKm);
-            PaceText = $"{(int)pace.TotalMinutes}:{pace.Seconds:00}";
         }
 
         BuildProfiles(locations);
@@ -196,11 +168,6 @@ public partial class TripOverviewViewModel : ObservableObject
             await Navigation.ShellNavigationTo("TripChartsPage", new Dictionary<string, object> { { "parameter", Trip } });
         }
     }
-
-    private static string FormatDuration(TimeSpan duration) =>
-        duration.TotalHours >= 1
-            ? duration.ToString(@"h\:mm\:ss", GermanCulture)
-            : duration.ToString(@"mm\:ss", GermanCulture);
 
     private static string GetTripName(DateTimeOffset startTime)
     {


### PR DESCRIPTION
## Ursache: fehlende `RowDefinitions`

Die Analyse-Seite („Trip-Statistikseite") zeigte nur die Hälfte der Statistik-Chips. Das Chip-Grid deklarierte vier Spalten und vier Chips in `Grid.Row="1"` — aber **keine `RowDefinitions`**.

MAUI erzeugt dann genau eine implizite `Star`-Zeile und **klemmt** `Grid.Row` per `Clamp` auf die letzte definierte Zeile (`GridLayoutManager.InitializeCells`). Beide Chip-Reihen landeten also in Zeile 0 und zeichneten sich exakt übereinander — vier Werte (Bewegung, Pause, Höhe, Pace) waren verdeckt.

Gegenprobe aus dem decompilierten `Microsoft.Maui.dll` (preview.7):

```csharp
int num3 = NumericExtensions.Clamp(_grid.GetRow(view), 0, _rows.Length - 1);
```

## Änderungen

- **`TripChartsPage.xaml`**: `RowDefinitions="Auto,Auto"` ergänzt → alle 8 Werte sind sichtbar (Distanz, Dauer, Ø km/h, Max km/h, Bewegung, Pause, Höhe, Pace), darunter unverändert die drei Charts (Geschwindigkeit, Höhenprofil, Pace).
- **`TripOverviewPage.xaml`**: die vier zusätzlichen Chips wieder entfernt — das Overlay ist wieder so schlank wie vorher. Der Tipp-Toggle auf der Karte (Overlays aus/ein) bleibt.
- **`TripOverviewViewModel`**: die dadurch ungenutzten Eigenschaften `MovingTimeText`, `StoppedTimeText`, `AltitudeText`, `PaceText` inkl. Berechnung entfernt.
- **`UniTracks.Tests/Views/XamlGridLayoutTests.cs`** (neu): prüft alle XAML-Dateien darauf, dass kein `Grid.Row`/`Grid.Column` über die deklarierten Zeilen/Spalten hinausgeht. Verifiziert: ohne den Fix schlägt er mit genau dieser Datei fehl.

## Verifikation

- Tests: **151/151 grün**.
- iOS-Build (`net11.0-ios`, preview.7): 0 Fehler.