### PR TITLE
Android-Fixes und gemeinsames Münzkonto (0.4.0)

### DIFF
--- a/UniTracks.Games/CityBuilder/CityEngine.cs
+++ b/UniTracks.Games/CityBuilder/CityEngine.cs
@@ -17,16 +17,21 @@ public static class CityEngine
     /// <param name="placed">Persisted buildings (from the repository).</param>
     /// <param name="expansions">Purchased grid expansions.</param>
     /// <param name="stats">Lifetime activity (trips with type info, XP, achievements).</param>
+    /// <param name="coinsSpentInOtherGames">
+    /// Coins the player spent outside the city (currently tower unlocks and coin-funded energy).
+    /// The account is shared, so the spendable balance has to subtract them as well.
+    /// </param>
     public static CityState Rebuild(
         IEnumerable<PlacedBuilding> placed,
         IEnumerable<CityExpansion> expansions,
-        ActivityStats stats)
+        ActivityStats stats,
+        int coinsSpentInOtherGames = 0)
     {
         var placedList = placed.ToList();
         var expansionList = expansions.ToList();
         int gridSize = CityExpansions.ResolveGridSize(expansionList.Select(e => e.GridSize));
         int earned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements);
-        int spent = ComputeSpent(placedList) + ComputeExpansionSpent(expansionList);
+        int spent = ComputeTotalSpent(placedList, expansionList) + coinsSpentInOtherGames;
 
         var tiles = new List<CityTile>(gridSize * gridSize);
         for (int y = 0; y < gridSize; y++)
@@ -65,6 +70,10 @@ public static class CityEngine
     /// <summary>Coins invested in purchased expansions (priced via the progression table).</summary>
     public static int ComputeExpansionSpent(IEnumerable<CityExpansion> expansions) =>
         expansions.Sum(e => CityExpansions.Steps.FirstOrDefault(s => s.GridSize == e.GridSize)?.Cost ?? 0);
+
+    /// <summary>Everything the city has cost so far — buildings plus expansions.</summary>
+    public static int ComputeTotalSpent(IEnumerable<PlacedBuilding> placed, IEnumerable<CityExpansion> expansions) =>
+        ComputeSpent(placed) + ComputeExpansionSpent(expansions);
 
     /// <summary>Validates a placement request. Does not mutate anything.</summary>
     public static PlaceResult ValidatePlacement(CityState city, string buildingId, int x, int y)

--- a/UniTracks.Games/CityBuilder/CityState.cs
+++ b/UniTracks.Games/CityBuilder/CityState.cs
@@ -10,13 +10,16 @@ public record CityState
     /// <summary>All tiles, row-major (Y * GridSize + X). Always GridSize² entries.</summary>
     public IReadOnlyList<CityTile> Tiles { get; init; } = Array.Empty<CityTile>();
 
-    /// <summary>Spendable coins (earned − spent).</summary>
+    /// <summary>Spendable coins (earned − spent in every game, shared account).</summary>
     public int Coins { get; init; }
 
-    /// <summary>Total coins ever earned through trips and achievements.</summary>
+    /// <summary>Total coins ever earned through trips, levels and achievements.</summary>
     public int CoinsEarned { get; init; }
 
-    /// <summary>Total coins spent on buildings and city expansions.</summary>
+    /// <summary>
+    /// Total coins spent across all games — this city's buildings and expansions plus what the
+    /// tower defense game consumed (tower unlocks and coin-funded energy).
+    /// </summary>
     public int CoinsSpent { get; init; }
 
     /// <summary>Gamification level — gates buildings and expansions.</summary>

--- a/UniTracks.Games/Shared/Economy/CoinAccount.cs
+++ b/UniTracks.Games/Shared/Economy/CoinAccount.cs
@@ -1,0 +1,24 @@
+namespace UniTracks.Games.Shared.Economy;
+
+/// <summary>
+/// The player's single coin account, shared by every game: everything earned through real
+/// activity minus everything spent anywhere. Spending in one game therefore immediately
+/// reduces the balance the other games show and enforce.
+/// </summary>
+public record CoinAccount
+{
+    /// <summary>Coins earned through trips, level-ups and achievements (includes the welcome bonus).</summary>
+    public int Earned { get; init; }
+
+    /// <summary>Coins invested in the city builder — buildings and grid expansions.</summary>
+    public int CitySpent { get; init; }
+
+    /// <summary>Coins invested in the tower defense game — tower unlocks and coin-funded energy.</summary>
+    public int TowerDefenseSpent { get; init; }
+
+    /// <summary>Coins spent across all games.</summary>
+    public int Spent => CitySpent + TowerDefenseSpent;
+
+    /// <summary>Coins available right now — the same number in every game.</summary>
+    public int Balance => Math.Max(0, Earned - Spent);
+}

--- a/UniTracks.Games/TowerDefense/DefenseEngine.cs
+++ b/UniTracks.Games/TowerDefense/DefenseEngine.cs
@@ -39,6 +39,10 @@ public static class DefenseEngine
     public static int ComputeEnergySpent(IEnumerable<EnergyPurchase> purchases) =>
         purchases.Sum(p => p.Coins);
 
+    /// <summary>Everything the tower defense game has cost so far — unlocks plus energy top-ups.</summary>
+    public static int ComputeTotalSpent(IEnumerable<TowerUnlock> unlocks, IEnumerable<EnergyPurchase> purchases) =>
+        ComputeUnlockSpent(unlocks) + ComputeEnergySpent(purchases);
+
     /// <summary>Grants energy to the running budget — used for coin-funded top-ups.</summary>
     public static void GrantEnergy(DefenseState state, int energy) => state.Energy += energy;
 

--- a/UniTracks.Maui.Services/ApplicationModel/Permissions.cs
+++ b/UniTracks.Maui.Services/ApplicationModel/Permissions.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using UniTracks.Services.ApplicationModel;
 using UniTracks.Services.ApplicationModel.Permissions;
 
+using MauiPermissionException = Microsoft.Maui.ApplicationModel.PermissionException;
 using MauiPermissionStatus = Microsoft.Maui.ApplicationModel.PermissionStatus;
 using MauiPermissions = Microsoft.Maui.ApplicationModel.Permissions;
 using PermissionStatus = UniTracks.Services.ApplicationModel.PermissionStatus;
@@ -11,17 +13,44 @@ public class Permissions : UniTracks.Services.ApplicationModel.IPermissions
 {
     public async Task<PermissionStatus> CheckPermissionStatusAsync(Permission permission)
     {
-        return MapToPermissionStatus(await CheckMauiPermission(permission));
+        try
+        {
+            return MapToPermissionStatus(await CheckMauiPermission(permission));
+        }
+        catch (MauiPermissionException ex)
+        {
+            // A permission the platform manifest does not declare cannot be queried: MAUI throws
+            // instead of answering. Report it as denied so the caller stays in control - an
+            // undeclared permission must never tear the app down.
+            Debug.WriteLine($"Permission '{permission}' is not declared on this platform: {ex.Message}");
+            return PermissionStatus.Denied;
+        }
     }
 
     public async Task<PermissionStatus> RequestPermissionAsync(Permission permission)
     {
-        return MapToPermissionStatus(await RequestMauiPermission(permission));
+        try
+        {
+            return MapToPermissionStatus(await RequestMauiPermission(permission));
+        }
+        catch (MauiPermissionException ex)
+        {
+            Debug.WriteLine($"Permission '{permission}' is not declared on this platform: {ex.Message}");
+            return PermissionStatus.Denied;
+        }
     }
 
     public bool ShouldShowRationale(Permission permission)
     {
-        return ShowRationalMauiPermission(permission);
+        try
+        {
+            return ShowRationalMauiPermission(permission);
+        }
+        catch (MauiPermissionException ex)
+        {
+            Debug.WriteLine($"Permission '{permission}' is not declared on this platform: {ex.Message}");
+            return false;
+        }
     }
 
     private PermissionStatus MapToPermissionStatus(MauiPermissionStatus mauiPermissionStatus)

--- a/UniTracks.Maui.Views/Controls/MapView.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/MapView.xaml.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using BruTile.Predefined;
+using BruTile.Web;
 using CommunityToolkit.Maui;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Projections;
-using Mapsui.Tiling;
+using Mapsui.Tiling.Layers;
+using Microsoft.Maui.ApplicationModel;
 using Coordinate = NetTopologySuite.Geometries.Coordinate;
 using GeometryFeature = Mapsui.Nts.GeometryFeature;
 using LineString = NetTopologySuite.Geometries.LineString;
@@ -19,8 +23,43 @@ public partial class MapView : ContentView
     public MapView()
     {
         InitializeComponent();
-        ControlMapView.Map.Layers.Add(OpenStreetMap.CreateTileLayer());
+        ControlMapView.Map.Layers.Add(CreateOpenStreetMapLayer());
         ControlMapView.Map.Navigator.RotationLock = true;
+    }
+
+    // The OpenStreetMap tile usage policy requires a User-Agent that identifies the app. Android's
+    // native HTTP handler (HttpURLConnection, backed by OkHttp) replaces the header with a generic
+    // client one, which the tile server rejects with an "Access blocked" tile. The layer therefore
+    // uses its own HttpClient on the managed handler, which sends the header unchanged.
+    private const string TileUserAgentFallbackVersion = "0.0.0";
+
+    private static TileLayer CreateOpenStreetMapLayer()
+    {
+        var userAgent = $"UniTracks/{GetAppVersion()} (+https://github.com/Agredo/UniTracks)";
+
+        var tileSource = new HttpTileSource(
+            new GlobalSphericalMercator(),
+            "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+            name: "OpenStreetMap",
+            attribution: new BruTile.Attribution("© OpenStreetMap contributors", "https://www.openstreetmap.org/copyright"),
+            configureHttpRequestMessage: request => request.Headers.TryAddWithoutValidation("User-Agent", userAgent));
+
+        var httpClient = new HttpClient(new SocketsHttpHandler());
+        httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgent);
+
+        return new TileLayer(tileSource, httpClient: httpClient) { Name = "OpenStreetMap" };
+    }
+
+    private static string GetAppVersion()
+    {
+        try
+        {
+            return AppInfo.Current.VersionString;
+        }
+        catch
+        {
+            return TileUserAgentFallbackVersion;
+        }
     }
 
     [BindableProperty(PropertyChangedMethodName = nameof(OnLocationsPropertyChanged))]

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -162,6 +162,7 @@ public static class MauiProgram
         services.AddSingleton<ICoinService, CoinService>();
         services.AddSingleton<IActivityStatsSource>(sp => sp.GetRequiredService<ICoinService>());
         services.AddSingleton<ICityStore, CityStore>();
+        services.AddSingleton<ICoinAccountService, CoinAccountService>();
         services.AddSingleton<ICityBuilderService, CityBuilderService>();
         services.AddSingleton<ITowerDefenseStore, TowerDefenseStore>();
         services.AddSingleton<ITowerDefenseService, TowerDefenseService>();

--- a/UniTracks.Maui/UniTracks.Maui.csproj
+++ b/UniTracks.Maui/UniTracks.Maui.csproj
@@ -17,8 +17,8 @@
 		<ApplicationId>com.agredoapplication.unitracks</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>0.3.1</ApplicationDisplayVersion>
-		<ApplicationVersion>3</ApplicationVersion>
+		<ApplicationDisplayVersion>0.4</ApplicationDisplayVersion>
+		<ApplicationVersion>4</ApplicationVersion>
 
 		<DefaultLanguage>de-DE</DefaultLanguage>
 	</PropertyGroup>

--- a/UniTracks.Services/Game/CityBuilderService.cs
+++ b/UniTracks.Services/Game/CityBuilderService.cs
@@ -13,11 +13,13 @@ public class CityBuilderService : ICityBuilderService
 {
     private readonly ICityStore cityStore;
     private readonly IActivityStatsSource activityStats;
+    private readonly ICoinAccountService coinAccount;
 
-    public CityBuilderService(ICityStore cityStore, IActivityStatsSource activityStats)
+    public CityBuilderService(ICityStore cityStore, IActivityStatsSource activityStats, ICoinAccountService coinAccount)
     {
         this.cityStore = cityStore;
         this.activityStats = activityStats;
+        this.coinAccount = coinAccount;
     }
 
     public async Task<CityState> GetCityAsync()
@@ -25,7 +27,10 @@ public class CityBuilderService : ICityBuilderService
         var placed = await cityStore.LoadAsync();
         var expansions = await cityStore.LoadExpansionsAsync();
         var stats = await activityStats.GetAsync();
-        return CityEngine.Rebuild(placed, expansions, stats);
+
+        // The account is shared with the tower defense game, so its spending is gone here too.
+        var account = await coinAccount.GetAsync();
+        return CityEngine.Rebuild(placed, expansions, stats, account.TowerDefenseSpent);
     }
 
     public async Task<PlaceResult> TryPlaceAsync(string buildingId, int x, int y)

--- a/UniTracks.Services/Game/CoinAccountService.cs
+++ b/UniTracks.Services/Game/CoinAccountService.cs
@@ -1,0 +1,43 @@
+using UniTracks.Games.CityBuilder;
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Economy;
+using UniTracks.Games.Shared.Persistence;
+using UniTracks.Games.TowerDefense;
+using UniTracks.Games.TowerDefense.Persistence;
+
+namespace UniTracks.Services.Game;
+
+/// <summary>
+/// Single source of truth for the shared coin account: sums what the player earned from real
+/// activity and what every game has spent. The balance is computed on every read and never
+/// stored, so it can neither drift out of sync with the trip data nor between the games.
+/// </summary>
+public class CoinAccountService : ICoinAccountService
+{
+    private readonly ICityStore cityStore;
+    private readonly ITowerDefenseStore towerDefenseStore;
+    private readonly IActivityStatsSource activityStats;
+
+    public CoinAccountService(ICityStore cityStore, ITowerDefenseStore towerDefenseStore, IActivityStatsSource activityStats)
+    {
+        this.cityStore = cityStore;
+        this.towerDefenseStore = towerDefenseStore;
+        this.activityStats = activityStats;
+    }
+
+    public async Task<CoinAccount> GetAsync()
+    {
+        var stats = await activityStats.GetAsync();
+        var placed = await cityStore.LoadAsync();
+        var expansions = await cityStore.LoadExpansionsAsync();
+        var unlocks = await towerDefenseStore.LoadUnlocksAsync();
+        var energyPurchases = await towerDefenseStore.LoadEnergyPurchasesAsync();
+
+        return new CoinAccount
+        {
+            Earned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements),
+            CitySpent = CityEngine.ComputeTotalSpent(placed, expansions),
+            TowerDefenseSpent = DefenseEngine.ComputeTotalSpent(unlocks, energyPurchases),
+        };
+    }
+}

--- a/UniTracks.Services/Game/GameCatalogService.cs
+++ b/UniTracks.Services/Game/GameCatalogService.cs
@@ -1,28 +1,20 @@
 using UniTracks.Games.Catalog;
-using UniTracks.Games.CityBuilder;
-using UniTracks.Games.CityBuilder.Persistence;
-using UniTracks.Games.Shared.Economy;
 using UniTracks.Games.Shared.Persistence;
-using UniTracks.Games.TowerDefense;
-using UniTracks.Games.TowerDefense.Persistence;
 
 namespace UniTracks.Services.Game;
 
 /// <summary>
-/// Game registry plus the shared coin balance: coins are earned from activity and
-/// spent across all games (city buildings, expansions, tower unlocks) — always
-/// computed, never stored, so cross-game spending can never drift apart.
+/// Game registry plus the shared coin balance. The balance itself comes from
+/// <see cref="ICoinAccountService"/>, so the catalog and both games always agree.
 /// </summary>
 public class GameCatalogService : IGameCatalogService
 {
-    private readonly ICityStore cityStore;
-    private readonly ITowerDefenseStore towerDefenseStore;
+    private readonly ICoinAccountService coinAccount;
     private readonly IActivityStatsSource activityStats;
 
-    public GameCatalogService(ICityStore cityStore, ITowerDefenseStore towerDefenseStore, IActivityStatsSource activityStats)
+    public GameCatalogService(ICoinAccountService coinAccount, IActivityStatsSource activityStats)
     {
-        this.cityStore = cityStore;
-        this.towerDefenseStore = towerDefenseStore;
+        this.coinAccount = coinAccount;
         this.activityStats = activityStats;
     }
 
@@ -30,18 +22,5 @@ public class GameCatalogService : IGameCatalogService
 
     public async Task<ActivityStats> GetActivityStatsAsync() => await activityStats.GetAsync();
 
-    public async Task<int> GetCoinBalanceAsync()
-    {
-        var stats = await activityStats.GetAsync();
-        var placed = await cityStore.LoadAsync();
-        var expansions = await cityStore.LoadExpansionsAsync();
-        var unlocks = await towerDefenseStore.LoadUnlocksAsync();
-        var energyPurchases = await towerDefenseStore.LoadEnergyPurchasesAsync();
-        int earned = CoinEconomy.ComputeEarned(stats.Trips, stats.Xp, stats.UnlockedAchievements);
-        int spent = CityEngine.ComputeSpent(placed)
-            + CityEngine.ComputeExpansionSpent(expansions)
-            + DefenseEngine.ComputeUnlockSpent(unlocks)
-            + DefenseEngine.ComputeEnergySpent(energyPurchases);
-        return Math.Max(0, earned - spent);
-    }
+    public async Task<int> GetCoinBalanceAsync() => (await coinAccount.GetAsync()).Balance;
 }

--- a/UniTracks.Services/Game/ICoinAccountService.cs
+++ b/UniTracks.Services/Game/ICoinAccountService.cs
@@ -1,0 +1,12 @@
+using UniTracks.Games.Shared.Economy;
+
+namespace UniTracks.Services.Game;
+
+/// <summary>
+/// Supplies the shared coin account. Every game reads its balance from here, so the city
+/// builder and the tower defense game can never disagree about how many coins are left.
+/// </summary>
+public interface ICoinAccountService
+{
+    Task<CoinAccount> GetAsync();
+}

--- a/UniTracks.Tests/Game/Fakes/InMemoryGameStores.cs
+++ b/UniTracks.Tests/Game/Fakes/InMemoryGameStores.cs
@@ -1,0 +1,45 @@
+using UniTracks.Games.CityBuilder.Persistence;
+using UniTracks.Games.Shared.Persistence;
+
+namespace UniTracks.Tests.Game.Fakes;
+
+/// <summary>In-memory <see cref="ICityStore"/> — same write-through semantics as the real store.</summary>
+internal sealed class InMemoryCityStore : ICityStore
+{
+    private readonly List<PlacedBuilding> placed = new();
+    private readonly List<CityExpansion> expansions = new();
+
+    public Task<IReadOnlyList<PlacedBuilding>> LoadAsync() =>
+        Task.FromResult<IReadOnlyList<PlacedBuilding>>(placed.ToList());
+
+    public Task SaveAsync(PlacedBuilding building)
+    {
+        placed.Add(building);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(PlacedBuilding building)
+    {
+        placed.RemoveAll(p => p.ID == building.ID);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<CityExpansion>> LoadExpansionsAsync() =>
+        Task.FromResult<IReadOnlyList<CityExpansion>>(expansions.ToList());
+
+    public Task SaveExpansionAsync(CityExpansion expansion)
+    {
+        expansions.Add(expansion);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>In-memory <see cref="IActivityStatsSource"/> returning a fixed lifetime snapshot.</summary>
+internal sealed class FakeActivityStatsSource : IActivityStatsSource
+{
+    public FakeActivityStatsSource(ActivityStats stats) => Stats = stats;
+
+    public ActivityStats Stats { get; set; }
+
+    public Task<ActivityStats> GetAsync() => Task.FromResult(Stats);
+}

--- a/UniTracks.Tests/Game/SharedCoinBalanceTests.cs
+++ b/UniTracks.Tests/Game/SharedCoinBalanceTests.cs
@@ -1,0 +1,94 @@
+using UniTracks.Games.Shared.Persistence;
+using UniTracks.Games.TowerDefense.Persistence;
+using UniTracks.Services.Game;
+using UniTracks.Tests.Game.Fakes;
+using UniTracks.Tests.TowerDefense.Fakes;
+
+namespace UniTracks.Tests.Game;
+
+/// <summary>
+/// The coin account is shared by both games: what the city builder reports as spendable
+/// must be the same number the catalog (and therefore the tower defense shop) reports.
+/// </summary>
+public class SharedCoinBalanceTests
+{
+    private static ActivityStats FortyKmRun => new()
+    {
+        Trips = new[] { new TripActivity { DistanceKm = 40, Category = "running", Identifier = "run" } },
+        Xp = 200,
+    };
+
+    [Fact]
+    public async Task CityBuilderBalance_MatchesTheSharedBalance_AcrossBothGames()
+    {
+        // 500 welcome + 400 distance (40 km × 1,0 × 10) + 5 trip + 500 level bonus = 1405 earned.
+        var stats = FortyKmRun;
+        var cityStore = new InMemoryCityStore();
+        var towerStore = new InMemoryTowerDefenseStore();
+        var statsSource = new FakeActivityStatsSource(stats);
+        var account = new CoinAccountService(cityStore, towerStore, statsSource);
+
+        var cityBuilder = new CityBuilderService(cityStore, statsSource, account);
+        await towerStore.SaveUnlockAsync(new TowerUnlock { ID = Guid.NewGuid(), TowerId = "zapper" });
+        await towerStore.SaveEnergyPurchaseAsync(new EnergyPurchase { ID = Guid.NewGuid(), Energy = 50, Coins = 100 });
+        await cityBuilder.TryPlaceAsync("flowerbed", 0, 0);
+
+        int shared = await new GameCatalogService(account, statsSource).GetCoinBalanceAsync();
+        var city = await cityBuilder.GetCityAsync();
+
+        Assert.True(city.CoinsSpent > 0, "the placed building must count as city spending");
+        Assert.Equal(shared, city.Coins);
+    }
+
+    [Fact]
+    public async Task TowerDefenseSpending_ReducesTheCityBalance()
+    {
+        var cityStore = new InMemoryCityStore();
+        var towerStore = new InMemoryTowerDefenseStore();
+        var statsSource = new FakeActivityStatsSource(FortyKmRun);
+        var account = new CoinAccountService(cityStore, towerStore, statsSource);
+        var cityBuilder = new CityBuilderService(cityStore, statsSource, account);
+
+        int before = (await cityBuilder.GetCityAsync()).Coins;
+        await towerStore.SaveUnlockAsync(new TowerUnlock { ID = Guid.NewGuid(), TowerId = "zapper" });
+        int after = (await cityBuilder.GetCityAsync()).Coins;
+
+        Assert.Equal(before - 400, after);
+    }
+
+    [Fact]
+    public async Task CitySpending_ReducesTheTowerDefenseBalance()
+    {
+        var cityStore = new InMemoryCityStore();
+        var towerStore = new InMemoryTowerDefenseStore();
+        var statsSource = new FakeActivityStatsSource(FortyKmRun);
+        var account = new CoinAccountService(cityStore, towerStore, statsSource);
+        var cityBuilder = new CityBuilderService(cityStore, statsSource, account);
+        var catalog = new GameCatalogService(account, statsSource);
+
+        int before = await catalog.GetCoinBalanceAsync();
+        await cityBuilder.TryPlaceAsync("flowerbed", 0, 0);
+        int after = await catalog.GetCoinBalanceAsync();
+
+        Assert.Equal(before - 15, after);
+    }
+
+    [Fact]
+    public async Task CityBuilder_CannotSpendCoinsAlreadySpentInTowerDefense()
+    {
+        var cityStore = new InMemoryCityStore();
+        var towerStore = new InMemoryTowerDefenseStore();
+        var statsSource = new FakeActivityStatsSource(FortyKmRun);
+        var account = new CoinAccountService(cityStore, towerStore, statsSource);
+        var cityBuilder = new CityBuilderService(cityStore, statsSource, account);
+
+        // 1405 earned − 650 unlock = 755 left: the 15-coin flowerbed is still affordable.
+        await towerStore.SaveUnlockAsync(new TowerUnlock { ID = Guid.NewGuid(), TowerId = "frog" });
+
+        var result = await cityBuilder.TryPlaceAsync("flowerbed", 0, 0);
+        var city = await cityBuilder.GetCityAsync();
+
+        Assert.True(result.Success, "a 15-coin building must still be affordable");
+        Assert.Equal(1405 - 650 - 15, city.Coins);
+    }
+}

--- a/UniTracks.ViewModels/Pages/HelpPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/HelpPageViewModel.cs
@@ -61,7 +61,7 @@ public partial class HelpPageViewModel : ObservableObject
             {
                 Title = "So funktioniert das Münzsystem",
                 Icon = "💡",
-                Body = "Münzen werden nie gespeichert — der Saldo wird bei jedem Öffnen des Spiel-Bereichs automatisch aus deinen echten Trips, Errungenschaften und Level neu berechnet. Neue Aktivität erhöht ihn sofort; Ausgaben werden abgezogen. So kann das Konto nie auseinanderlaufen.",
+                Body = "Münzen werden nie gespeichert — der Saldo wird bei jedem Öffnen des Spiel-Bereichs automatisch aus deinen echten Trips, Errungenschaften und Level neu berechnet. Neue Aktivität erhöht ihn sofort; Ausgaben werden abgezogen. Cozy City und Trail Defense teilen sich ein einziges Konto: Was du im einen Spiel ausgibst, fehlt sofort im anderen. So kann das Konto nie auseinanderlaufen.",
             },
             new HelpItem
             {

--- a/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
+++ b/UniTracks.ViewModels/Pages/Tabs/RecordTripTabPageViewModel.cs
@@ -176,15 +176,17 @@ public partial class RecordTripTabPageViewModel : ObservableObject
         // switched first and the result only used to decide whether to start listening, so a denied
         // permission left the page showing "Aufnahme läuft" with a running timer while nothing was
         // recorded.
-        PermissionStatus locationPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, Permission.LocationAlways);
+        //
+        // Android fragt direkt LocationWhenInUse an: ACCESS_BACKGROUND_LOCATION ist dort bewusst
+        // nicht im Manifest (siehe AndroidManifest.xml), weil ein im Vordergrund gestarteter
+        // location-Foreground-Service auch im Hintergrund weiter aufzeichnen darf (While-in-Use
+        // reicht). Permissions.LocationAlways wirft ohne diesen Manifest-Eintrag eine
+        // PermissionException und hat die App hier beim Start der Aufnahme abgestuerzt.
+        Permission locationPermission = OperatingSystem.IsAndroid()
+            ? Permission.LocationWhenInUse
+            : Permission.LocationAlways;
 
-        // Ab Android 11 kann "Immer zulassen" nur noch in den Systemeinstellungen erteilt
-        // werden und ist hier nicht noetig: Der location-Foreground-Service wird im Vordergrund
-        // gestartet und darf damit auch im Hintergrund weiter aufzeichnen (While-in-Use reicht).
-        if (locationPermissionStatus is not PermissionStatus.Granted && OperatingSystem.IsAndroid())
-        {
-            locationPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, Permission.LocationWhenInUse);
-        }
+        PermissionStatus locationPermissionStatus = await PermissionHelper.CheckAndRequestPermission(Permissions, locationPermission);
 
         if (locationPermissionStatus is not PermissionStatus.Granted)
         {

--- a/build-unitracks.bat
+++ b/build-unitracks.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set VERSION=0.1
+set VERSION=0.4
 set PROJECT=UniTracks.Maui\UniTracks.Maui.csproj
 set ANDROID_TFM=net11.0-android
 set WINDOWS_TFM=net11.0-windows10.0.26100.0


### PR DESCRIPTION
## Zusammenfassung

Vier zusammenhängende Änderungen aus dem Android-Deployment:

1. **Absturz beim Anlegen eines Users / Starten eines Laufs** (`94d9752`)
   `RecordTripTabPageViewModel.StartListening` forderte unbedingt `Permission.LocationAlways` an, obwohl `ACCESS_BACKGROUND_LOCATION` seit `1d1165d` nicht mehr im Manifest steht → `PermissionException`. Auf Android wird jetzt `LocationWhenInUse` angefragt; `Permissions.cs` fängt `MauiPermissionException` ab.

2. **„Access blocked" auf der Karte** (`844d241`)
   Androids HTTP-Stack ersetzt den `User-Agent` durch `okhttp/<version>`, den OpenStreetMap mit einer 403-Kachel (6987 B) beantwortet. Die OSM-Kachelschicht läuft jetzt über einen eigenen `HttpTileSource` mit `SocketsHttpHandler` und sprechendem User-Agent (echte Kachel: 20970 B). iOS war nicht betroffen.

3. **Version 0.4.0** (`0e32da8`)
   `ApplicationDisplayVersion` 0.4, `ApplicationVersion` 4; `build-unitracks.bat` nachgezogen.

4. **Ein gemeinsames Münzkonto für Cozy City und Trail Defense** (`bb18055`)
   `CityEngine.Rebuild` zog nur die Stadt-Ausgaben ab und ignorierte Turm-Freischaltungen sowie mit Münzen gekaufte Energie. Dadurch zeigte CityBuilder mehr Münzen an als Trail Defense (im Fehlerfall 1390 statt 890) und erlaubte Käufe, die das geteilte Konto nicht mehr hergab. Münzen werden nie gespeichert — ein Alt-Datenbank-Artefakt war ausgeschlossen.
   Neu: `CoinAccount` + `CoinAccountService` als einzige Quelle des Saldos (`500 + X − Ausgaben aller Spiele`, bei jedem Lesen neu berechnet). `GameCatalogService` delegiert dorthin, `CityEngine.Rebuild` bekommt die Fremdausgaben übergeben — damit stimmen Anzeige, Shop-Verfügbarkeit und Platzierungsprüfung in beiden Spielen überein.

## Tests

`UniTracks.Tests`: **155 Tests, 0 Fehler** (4 neue in `SharedCoinBalanceTests`, die den Bug zuerst reproduziert haben).

## Hinweise

Die APK 0.4.0 ist gebaut (`C:\Projects\UniTracks\dist\`), aber noch nicht auf einem Gerät installiert — die Verifikation des OSM-Fixes und des Absturz-Fixes auf Hardware steht noch aus.