### PR TITLE
Overlays per Tippen ausblenden und Popup-Rahmen entfernen

### DIFF
--- a/UniTracks.Maui.Views/Controls/MapView.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/MapView.xaml.cs
@@ -2,13 +2,16 @@
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Windows.Input;
 using BruTile.Predefined;
 using BruTile.Web;
 using CommunityToolkit.Maui;
 using Mapsui;
 using Mapsui.Layers;
+using Mapsui.Manipulations;
 using Mapsui.Projections;
 using Mapsui.Tiling.Layers;
+using Mapsui.UI;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Dispatching;
 using Coordinate = NetTopologySuite.Geometries.Coordinate;
@@ -43,6 +46,7 @@ public partial class MapView : ContentView
         InitializeComponent();
         ControlMapView.Map.Layers.Add(CreateOpenStreetMapLayer());
         ControlMapView.Map.Navigator.RotationLock = true;
+        ControlMapView.MapTapped += OnMapTapped;
 
         // The animation only runs while the view is on screen, so it costs nothing once the trip
         // page has been left.
@@ -103,6 +107,32 @@ public partial class MapView : ContentView
         if (bindable is MapView mapView && newValue is IReadOnlyList<Location> locations)
         {
             mapView.DrawRoute(locations);
+        }
+    }
+
+    public static readonly BindableProperty TapCommandProperty = BindableProperty.Create(
+        nameof(TapCommand), typeof(ICommand), typeof(MapView));
+
+    public ICommand? TapCommand
+    {
+        get => (ICommand?)GetValue(TapCommandProperty);
+        set => SetValue(TapCommandProperty, value);
+    }
+
+    // The Mapsui MapControl hosts a SkiaSharp view that marks every touch as handled, so a
+    // TapGestureRecognizer on this ContentView never fires on Android. Mapsui's own tap detection
+    // is used instead; it ignores movements beyond MaxTapGestureMovement, which keeps panning and
+    // zooming unaffected.
+    private void OnMapTapped(object? sender, MapEventArgs e)
+    {
+        if (e.GestureType != GestureType.SingleTap)
+        {
+            return;
+        }
+
+        if (TapCommand?.CanExecute(null) == true)
+        {
+            TapCommand.Execute(null);
         }
     }
 

--- a/UniTracks.Maui.Views/Controls/Popups/PopupSizing.cs
+++ b/UniTracks.Maui.Views/Controls/Popups/PopupSizing.cs
@@ -1,0 +1,38 @@
+namespace UniTracks.Maui.Views.Controls.Popups;
+
+/// <summary>
+/// CommunityToolkit popups are sized to their content and only ever lay it out centred, so a popup
+/// that must not touch the screen edges needs an explicit content width. Deriving that width from
+/// the current display keeps the side margin on phones and tablets alike.
+/// </summary>
+public static class PopupSizing
+{
+    /// <summary>
+    /// Space kept between a popup and the edge of the screen.
+    /// </summary>
+    public const double SideMargin = 20;
+
+    private const double MaxContentWidth = 420;
+
+    private const double MinContentWidth = 240;
+
+    /// <summary>
+    /// Width for the card inside a popup.
+    /// </summary>
+    public static double ContentWidth
+    {
+        get
+        {
+            var display = DeviceDisplay.MainDisplayInfo;
+
+            if (display.Density <= 0 || display.Width <= 0)
+            {
+                return MaxContentWidth;
+            }
+
+            var screenWidth = display.Width / display.Density;
+
+            return Math.Clamp(screenWidth - (SideMargin * 2), MinContentWidth, MaxContentWidth);
+        }
+    }
+}

--- a/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml
+++ b/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml
@@ -7,7 +7,6 @@
     xmlns:vm="clr-namespace:UniTracks.ViewModels.Controls.Popups;assembly=UniTracks.ViewModels"
     xmlns:models="clr-namespace:UniTracks.Models.Trip;assembly=UniTracks.Models"
     x:DataType="vm:TripTypeSearchPopupViewModel"
-    BackgroundColor="Transparent"
     CanBeDismissedByTappingOutsideOfPopup="True">
 
     <toolkit:Popup.Resources>
@@ -25,11 +24,9 @@
     </toolkit:Popup.Resources>
 
     <Border
+        x:Name="PopupCard"
         Padding="24"
-        Style="{StaticResource CardBorder}"
-        Stroke="Transparent"
-        StrokeThickness="0"
-        WidthRequest="420">
+        Style="{StaticResource CardBorder}">
         <VerticalStackLayout Spacing="12">
 
             <Label Style="{StaticResource TitleLabel}" Text="Trip-Typ suchen" />

--- a/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/Popups/TripTypeSearchPopup.xaml.cs
@@ -11,6 +11,7 @@ public partial class TripTypeSearchPopup : Popup
 	public TripTypeSearchPopup(TripTypeSearchPopupViewModel viewModel)
 	{
 		InitializeComponent();
+		PopupCard.WidthRequest = PopupSizing.ContentWidth;
 
 		BindingContext = viewModel;
 		_viewModel = viewModel;

--- a/UniTracks.Maui.Views/Controls/Popups/UserCreationPopup.xaml
+++ b/UniTracks.Maui.Views/Controls/Popups/UserCreationPopup.xaml
@@ -32,9 +32,9 @@
     </toolkit:Popup.Resources>
 
     <Border
+        x:Name="PopupCard"
         Padding="24"
-        Style="{StaticResource CardBorder}"
-        WidthRequest="420">
+        Style="{StaticResource CardBorder}">
         <VerticalStackLayout Spacing="12">
 
             <Label Style="{StaticResource TitleLabel}" Text="Profil erstellen" />

--- a/UniTracks.Maui.Views/Controls/Popups/UserCreationPopup.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/Popups/UserCreationPopup.xaml.cs
@@ -10,6 +10,7 @@ public partial class UserCreationPopup : Popup
 	public UserCreationPopup(UserCreationPopupViewModel viewModel)
 	{
 		InitializeComponent();
+		PopupCard.WidthRequest = PopupSizing.ContentWidth;
 
 		BindingContext = viewModel;
 		_viewModel = viewModel;

--- a/UniTracks.Maui.Views/Controls/Popups/WhatsNewPopup.xaml
+++ b/UniTracks.Maui.Views/Controls/Popups/WhatsNewPopup.xaml
@@ -40,9 +40,9 @@
     </toolkit:Popup.Resources>
 
     <Border
+        x:Name="PopupCard"
         Padding="24"
-        Style="{StaticResource CardBorder}"
-        WidthRequest="420">
+        Style="{StaticResource CardBorder}">
         <VerticalStackLayout Spacing="14">
 
             <Label Style="{StaticResource TitleLabel}" Text="Was ist neu?" />

--- a/UniTracks.Maui.Views/Controls/Popups/WhatsNewPopup.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/Popups/WhatsNewPopup.xaml.cs
@@ -10,6 +10,7 @@ public partial class WhatsNewPopup : Popup
     public WhatsNewPopup(WhatsNewPopupViewModel viewModel)
     {
         InitializeComponent();
+        PopupCard.WidthRequest = PopupSizing.ContentWidth;
         BindingContext = viewModel;
         this.viewModel = viewModel;
         this.viewModel.Completed += OnCompleted;

--- a/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
+++ b/UniTracks.Maui.Views/Pages/TripOverviewPage.xaml
@@ -11,12 +11,10 @@
     x:DataType="vm:TripOverviewViewModel">
 
     <Grid>
-        <!-- Tapping the map toggles both overlay cards, so the route can be seen unobstructed. -->
-        <controls:MapView Locations="{Binding Locations}">
-            <controls:MapView.GestureRecognizers>
-                <TapGestureRecognizer Command="{Binding ToggleOverlayCommand}" />
-            </controls:MapView.GestureRecognizers>
-        </controls:MapView>
+        <!-- Tapping the map toggles both overlay cards, so the route can be seen unobstructed.
+             The tap comes from MapView itself: the Mapsui MapControl inside it consumes touch
+             events, which prevents a TapGestureRecognizer from ever firing on Android. -->
+        <controls:MapView Locations="{Binding Locations}" TapCommand="{Binding ToggleOverlayCommand}" />
 
         <!-- Floating stats card (tap for full analysis) -->
         <Border

--- a/UniTracks.Maui/MauiProgram.cs
+++ b/UniTracks.Maui/MauiProgram.cs
@@ -52,6 +52,16 @@ public static class MauiProgram
                         Stroke = new SolidColorBrush(Colors.Transparent),
                     },
                 });
+
+                // The toolkit paints every popup white and insets its content by 15, which showed up
+                // as a bright frame around the rounded card. The card now forms the whole popup and
+                // the margin keeps it clear of the screen edges.
+                options.SetPopupDefaults(new DefaultPopupSettings
+                {
+                    BackgroundColor = Colors.Transparent,
+                    Padding = new Thickness(0),
+                    Margin = new Thickness(PopupSizing.SideMargin),
+                });
             })
             .UseSkiaSharp()
             .ConfigureLifecycleEvents(events =>

--- a/UniTracks.Services/Changelog/changelog.json
+++ b/UniTracks.Services/Changelog/changelog.json
@@ -26,6 +26,14 @@
           "text": "Die Karte zeigt auf Android wieder Straßen statt \"Access blocked\"-Kacheln von OpenStreetMap."
         },
         {
+          "kind": "fix",
+          "text": "Tippen auf die Karte blendet die Statistik-Overlays auch auf Android aus, sodass die Strecke frei sichtbar ist."
+        },
+        {
+          "kind": "fix",
+          "text": "Popups haben keinen weißen Rand mehr und halten Abstand zum Bildschirmrand."
+        },
+        {
           "kind": "improvement",
           "text": "Cozy City und Trail Defense teilen sich ein gemeinsames Münzkonto: Ausgaben wirken sich auf beide Spiele aus."
         }


### PR DESCRIPTION
## Was geändert wurde

### Tippen auf die Karte blendet die Statistik-Overlays aus (Android)

Auf der Trip-Übersicht war das Ausblenden der Overlays per Tippen nur auf Windows/iOS wirksam. Auf Android hat das `TapGestureRecognizer` nie ausgelöst, weil das Mapsui-`MapControl` jeden Touch als behandelt markiert und MAUI den Tipp daher nicht sieht.

`MapView` gibt den Tipp jetzt über Mapsuis eigenes `MapTapped`-Ereignis als `TapCommand` weiter — dasselbe Muster wie `CityMapView.TileTappedCommand` und `DefenseMapView.TileTappedCommand`. Bewegungen über `MaxTapGestureMovement` hinaus werden von Mapsui ignoriert, Panning und Zoom bleiben also unberührt.

### Heller Rahmen um Popups entfernt

Das CommunityToolkit zeichnet Popups standardmäßig mit **weißem** Hintergrund und polstert den Inhalt mit 15 Einheiten. Um die abgerundete Karte (`CardBorder`, `CornerRadius=20`) war deshalb ein heller Rahmen sichtbar. `SetPopupDefaults` setzt den Hintergrund jetzt transparent und die Polsterung auf null, sodass die Karte das Popup vollständig bildet.

### Seitenränder für Popups

Popups hatten gar keinen Abstand zum Bildschirmrand. Das Toolkit legt Popup-Inhalte nur zentriert aus, weshalb die Kartenbreite weiterhin explizit gesetzt werden muss: `PopupSizing.ContentWidth` leitet sie aus der aktuellen Display-Breite ab und lässt 20 Einheiten Rand pro Seite stehen (Obergrenze 420, Untergrenze 240). Die drei Popup-Karten (`WhatsNewPopup`, `UserCreationPopup`, `TripTypeSearchPopup`) sind dadurch untereinander konsistent.

### Versionshinweise

`changelog.json` enthält für 0.4 jetzt auch die beiden Korrekturen, damit das Popup „Was ist neu?" sie anzeigt.

## Verifikation

- Android-Debug-Build: **0 Fehler**
- Testsuite: **218 Tests, 0 Fehler, 0 Fehlschläge**
- Auf dem Huawei P30 Pro installiert (`-t:Install`, ohne APK-Publish) und geprüft: keine hellen Pixel mehr am linken/rechten Bildschirmrand (vorher ein 39 px breites weißes Band), symmetrisch **61 px ≈ 22 Einheiten** Rand links und rechts, außerhalb der Karte ausschließlich dunkler Hintergrund.