### PR TITLE
Richtungspfeile etwas praesenter und schneller

### DIFF
--- a/UniTracks.Maui.Views/Controls/MapView.xaml.cs
+++ b/UniTracks.Maui.Views/Controls/MapView.xaml.cs
@@ -26,7 +26,7 @@ public partial class MapView : ContentView
     // Direction animation: an arrow travels the whole route in a fixed time, so a long track flows
     // at the same calm pace as a short one instead of racing away.
     private static readonly TimeSpan DirectionAnimationInterval = TimeSpan.FromMilliseconds(80);
-    private const double DirectionTraversalSeconds = 75;
+    private const double DirectionTraversalSeconds = 55;
     private const int DirectionArrowMinCount = 4;
     private const int DirectionArrowMaxCount = 40;
     private const double DirectionArrowMetresPerArrow = 300;
@@ -36,10 +36,10 @@ public partial class MapView : ContentView
     // symbol is 32 pixels wide and its shape cannot be changed. The chevron is exactly as wide as the
     // route pen, so it stays on the track instead of covering it.
     private const double DirectionArrowWidth = 5;
-    private const double DirectionArrowHeight = 7;
-    private const double DirectionArrowStrokeWidth = 1.3;
+    private const double DirectionArrowHeight = 9;
+    private const double DirectionArrowStrokeWidth = 1.7;
     private const int DirectionArrowColorSteps = 24;
-    private const double DirectionArrowLighten = 0.3;
+    private const double DirectionArrowLighten = 0.42;
 
     private MemoryLayer? routeLayer;
     private MemoryLayer? directionLayer;


### PR DESCRIPTION
## Was sich aendert

Die Richtungspfeile waren nach dem letzten Feinschliff arg zurueckhaltend. Sie bleiben so schmal wie die Strecke, werden aber etwas praesenter und laufen schneller:

- Hoehe **7 -> 9** Einheiten, Strichstaerke **1,3 -> 1,7**.
- Aufhellung **30 -> 42 Prozent**, damit sich der Pfeil klarer von der Streckenlinie abhebt.
- Ein voller Durchlauf dauert **55 statt 75 Sekunden**.

Die Breite bleibt bei 5 Einheiten, also genau die Breite der Streckenlinie.

## Version

Unveraendert **0.4** (versionCode 4).

## Geprueft

- Android-Debug-Build (`net11.0-android`): 0 Fehler.
- Auf dem P30 Pro installiert und die Strecke eines Trips geoeffnet: die Pixelprobe im Kartenbereich findet `#FF98A2`, also das um 42 Prozent aufgehellte Rot der Linie `#FF4D5E`, mit 197 Pixeln gegenueber 111 Pixeln vor der Aenderung.